### PR TITLE
NO-JIRA: Updates binary path in operator Containerfile

### DIFF
--- a/Containerfile.external-secrets-operator
+++ b/Containerfile.external-secrets-operator
@@ -17,7 +17,7 @@ ARG COMMIT_SHA
 ARG SOURCE_URL
 ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets-operator"
 
-COPY --from=builder $SOURCE_DIR/external-secrets-operator /bin/external-secrets-operator
+COPY --from=builder $SOURCE_DIR/bin/external-secrets-operator /bin/external-secrets-operator
 COPY --from=builder /licenses /licenses
 
 USER 65534:65534


### PR DESCRIPTION
The PR is for updating the binary path in the operator Containerfile `Containerfile.external-secrets-operator`