### PR TITLE
NO-JIRA: change to use deterministic tag for catalog image

### DIFF
--- a/.tekton/external-secrets-operator-fbc-push.yaml
+++ b/.tekton/external-secrets-operator-fbc-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/external-secrets-oap-tenant/external-secrets-operator-fbc/external-secrets-operator-fbc:{{revision}}
+    value: quay.io/redhat-user-workloads/external-secrets-oap-tenant/external-secrets-operator-fbc/external-secrets-operator-fbc:latest
   - name: dockerfile
     value: Containerfile.catalog
   - name: path-context


### PR DESCRIPTION
follow the PR https://github.com/openshift/cert-manager-operator-release/pull/411


[Open to discussion] Experimentally use deterministic tag for FBC image. This may eliminate the error-prone and redundant process to retrieve the latest catalog build for testing.
