### PR TITLE
ESO-83: Updates tekton PaC definitions with latest changes

### DIFF
--- a/.tekton/fbc-build-pipeline.yaml
+++ b/.tekton/fbc-build-pipeline.yaml
@@ -275,8 +275,10 @@ spec:
             - "false"
     - name: apply-tags
       params:
-        - name: IMAGE
+        - name: IMAGE_URL
           value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
         - build-image-index
       taskRef:


### PR DESCRIPTION
PR is for updating the tekton PaC definitions, where `apply-tags` task has been updated.