### PR TITLE
ESO-83: Update bitwarden-sdk-server image to previous build

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -7,7 +7,7 @@
 EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:6136d0271f7daa1ccb90264d4ebd9c41fb2ae937192b0df23d235586b246f9c9
 
 # bitwarden-sdk-server operand image digest.
-BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:6004a15f29478e35a28455d7ee6bacbfebd3f7b1be3581ecbf49a9b91ebe095f
+BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:269b6913c7f04df2895d23c69b940b4b311b628c51160e06e167be819e1d04f9
 
 # external-secrets-operator image digest.
 EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7ff4b3d94bd614a47990dfc96e043be4ff233ea772c5cf65fdaf9d06fa7d2984


### PR DESCRIPTION
PR is for reverting the bitwaden-sdk-server image to previous build, since fbc is flagging an issue with musl-gcc built binary.