### PR TITLE
ESO-83: Updates the release version build arg in tekton config

### DIFF
--- a/.tekton/external-secrets-0-1-pull-request.yaml
+++ b/.tekton/external-secrets-0-1-pull-request.yaml
@@ -34,7 +34,7 @@ spec:
     value: .
   - name: build-args
     value:
-      - RELEASE_VERSION=v0.14.0
+      - RELEASE_VERSION=v0.14.3
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/external-secrets-0-1-push.yaml
+++ b/.tekton/external-secrets-0-1-push.yaml
@@ -31,7 +31,7 @@ spec:
     value: .
   - name: build-args
     value:
-      - RELEASE_VERSION=v0.14.0
+      - RELEASE_VERSION=v0.14.3
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input


### PR DESCRIPTION
PR is for the updating the `RELEASE_VERSION` build arg in the `external-secrets` component's tekton config from `v0.14.0` to `v0.14.3`.