### PR TITLE
ESO-2: Enables snyk logs push for each component

### DIFF
--- a/.tekton/bitwarden-sdk-server-0-1-pull-request.yaml
+++ b/.tekton/bitwarden-sdk-server-0-1-pull-request.yaml
@@ -44,6 +44,10 @@ spec:
       - SOURCE_URL={{source_url}}
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "./cachi2-prefetch-configs/bitwarden-sdk-server/gomod"}, {"type": "generic", "path": "./cachi2-prefetch-configs/bitwarden-sdk-server/generics"}]'
+  - name: snyk-org-id
+    value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
+  - name: snyk-proj-name
+    value: "external-secrets-bitwarden-sdk-server"
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/bitwarden-sdk-server-0-1-push.yaml
+++ b/.tekton/bitwarden-sdk-server-0-1-push.yaml
@@ -41,6 +41,10 @@ spec:
       - SOURCE_URL={{source_url}}
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "./cachi2-prefetch-configs/bitwarden-sdk-server/gomod"}, {"type": "generic", "path": "./cachi2-prefetch-configs/bitwarden-sdk-server/generics"}]'
+  - name: snyk-org-id
+    value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
+  - name: snyk-proj-name
+    value: "external-secrets-bitwarden-sdk-server"
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/external-secrets-0-1-pull-request.yaml
+++ b/.tekton/external-secrets-0-1-pull-request.yaml
@@ -39,6 +39,10 @@ spec:
       - SOURCE_URL={{source_url}}
   - name: prefetch-input
     value: '{"type": "gomod", "path": "external-secrets"}'
+  - name: snyk-org-id
+    value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
+  - name: snyk-proj-name
+    value: "external-secrets"
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/external-secrets-0-1-push.yaml
+++ b/.tekton/external-secrets-0-1-push.yaml
@@ -36,6 +36,10 @@ spec:
       - SOURCE_URL={{source_url}}
   - name: prefetch-input
     value: '{"type": "gomod", "path": "external-secrets"}'
+  - name: snyk-org-id
+    value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
+  - name: snyk-proj-name
+    value: "external-secrets"
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/external-secrets-operator-0-1-pull-request.yaml
+++ b/.tekton/external-secrets-operator-0-1-pull-request.yaml
@@ -37,6 +37,10 @@ spec:
       - RELEASE_VERSION=v0.1.0
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
+  - name: snyk-org-id
+    value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
+  - name: snyk-proj-name
+    value: "external-secrets-operator"
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/external-secrets-operator-0-1-push.yaml
+++ b/.tekton/external-secrets-operator-0-1-push.yaml
@@ -34,6 +34,10 @@ spec:
       - RELEASE_VERSION=v0.1.0
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
+  - name: snyk-org-id
+    value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
+  - name: snyk-proj-name
+    value: "external-secrets-operator"
   pipelineRef:
     name: multi-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/external-secrets-operator-bundle-0-1-pull-request.yaml
+++ b/.tekton/external-secrets-operator-bundle-0-1-pull-request.yaml
@@ -40,6 +40,10 @@ spec:
       - SOURCE_URL={{source_url}}
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
+  - name: snyk-org-id
+    value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
+  - name: snyk-proj-name
+    value: "external-secrets-operator"
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/external-secrets-operator-bundle-0-1-push.yaml
+++ b/.tekton/external-secrets-operator-bundle-0-1-push.yaml
@@ -37,6 +37,10 @@ spec:
       - SOURCE_URL={{source_url}}
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
+  - name: snyk-org-id
+    value: "b6dda4fc-c9ea-48da-ac45-67f75f258e5a"
+  - name: snyk-proj-name
+    value: "external-secrets-operator"
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -22,6 +22,14 @@ spec:
             value: task
         resolver: bundles
   params:
+    - default: ""
+      description: Snyk Organization ID
+      name: snyk-org-id
+      type: string
+    - default: ""
+      description: Snyk Project Name
+      name: snyk-proj-name
+      type: string
     - description: Source Repository URL
       name: git-url
       type: string
@@ -368,6 +376,8 @@ spec:
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: ARGS
+          value: --project-name=$(params.snyk-proj-name) --report --org=$(params.snyk-org-id)
       runAfter:
         - build-image-index
       taskRef:

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -22,6 +22,14 @@ spec:
             value: task
         resolver: bundles
   params:
+    - default: ""
+      description: Snyk Organization ID
+      name: snyk-org-id
+      type: string
+    - default: ""
+      description: Snyk Project Name
+      name: snyk-proj-name
+      type: string
     - description: Source Repository URL
       name: git-url
       type: string
@@ -332,6 +340,8 @@ spec:
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: ARGS
+          value: --project-name=$(params.snyk-proj-name) --report --org=$(params.snyk-org-id)
       runAfter:
         - build-image-index
       taskRef:


### PR DESCRIPTION
PR configures the project name and organization ID as defined in snyk for external-secrets-operator and other upstream repositories to push the findings of snyk scan performed by `sast-snyk-check` to snyk portal.