### PR TITLE
ESO-161: Updates 4.20 fbc Containerfile base image

### DIFF
--- a/Containerfile.catalog
+++ b/Containerfile.catalog
@@ -1,1 +1,1 @@
-./catalogs/v4.19/Containerfile
+./catalogs/v4.20/Containerfile

--- a/catalog
+++ b/catalog
@@ -1,1 +1,1 @@
-./catalogs/v4.19/catalog
+./catalogs/v4.20/catalog

--- a/catalogs/v4.20/Containerfile
+++ b/catalogs/v4.20/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
PR has following changes
- Updates the 4.20 index Containerfile base image to use OCP-4.20 version.
- Updates current catalog softlink to 4.20 catalog