### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for bitwarden-sdk-server-0-1

### DIFF
--- a/Containerfile.bitwarden-sdk-server
+++ b/Containerfile.bitwarden-sdk-server
@@ -34,6 +34,7 @@ ENV BW_SECRETS_MANAGER_STATE_PATH='/state'
 USER 65534:65534
 
 LABEL com.redhat.component="external-secrets-bitwarden-sdk-server-container" \
+      cpe="cpe:/a:redhat:external_secrets_operator:0.1::el9" \
       name="external-secrets-operator/bitwarden-sdk-server-rhel9" \
       version="${RELEASE_VERSION}" \
       summary="external-secrets-bitwarden-sdk-server" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
