### PR TITLE
KONFLUX-6210: chore: fix and set name and cpe label for external-secrets-operator-0-1

### DIFF
--- a/Containerfile.external-secrets-operator
+++ b/Containerfile.external-secrets-operator
@@ -37,6 +37,7 @@ LABEL com.redhat.component="external-secrets-operator-container" \
       io.openshift.maintainer.product="OpenShift Container Platform" \
       io.openshift.tags="data,images,operator,external-secrets,external-secrets-operator" \
       io.k8s.display-name="openshift-external-secrets-operator" \
+      cpe="cpe:/a:redhat:external_secrets_operator:0.1::el9" \
       io.k8s.description="external-secrets-operator-container"
 
 ENTRYPOINT ["/bin/external-secrets-operator"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
