### PR TITLE
KONFLUX-6210: chore: fix and set name and cpe label for external-secrets-0-1

### DIFF
--- a/Containerfile.external-secrets
+++ b/Containerfile.external-secrets
@@ -36,6 +36,7 @@ LABEL com.redhat.component="external-secrets-container" \
       description="external-secrets-container" \
       vendor="Red Hat, Inc." \
       release="${RELEASE_VERSION}" \
+      cpe="cpe:/a:redhat:external_secrets_operator:0.1::el9" \
       io.openshift.expose-services="" \
       io.openshift.tags="data,images,external-secrets,external-secrets-operator" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
