### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for external-secrets-operator-bundle-0-1

### DIFF
--- a/Containerfile.external-secrets-operator.bundle
+++ b/Containerfile.external-secrets-operator.bundle
@@ -33,6 +33,7 @@ LABEL com.redhat.component="external-secrets-operator-bundle-container" \
       url="${SOURCE_URL}" \
       maintainer="Red Hat, Inc." \
       vendor="Red Hat, Inc." \
+      cpe="cpe:/a:redhat:external_secrets_operator:0.1::el9" \
       com.redhat.delivery.operator.bundle=true \
       com.redhat.openshift.versions="v4.19" \
       io.openshift.expose-services="" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
