### PR TITLE
NO-JIRA: Updated with latest sha of 0.2 version for rpms-signature-scan

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -603,7 +603,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:06977232e67509e5540528ff6c3b081b23fc5bf3e40fb3e2d09a086d5c3243fc
+            value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:57d9107fe4708b503f494cf4362fef770623fdb300641811f23a975cd597b024
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
Updated with latest sha of 0.2 version for rpms-signature-scan as existing older sha image was causing failure:

> ✕ [Violation] tasks.required_untrusted_task_found
>   ImageRef: quay.io/redhat-user-workloads/external-secrets-oap-tenant/bitwarden-sdk-server-1-0/bitwarden-sdk-server-1-0@sha256:8b47d8bf2ac183e40de7b8d0b8c5ad38ce2f4337cfa9bc62861a4ada5fd35272
>   Reason: Required task "rpms-signature-scan" is required and present but not from a trusted task
>   Term: rpms-signature-scan
>   Title: All required tasks are from trusted tasks
>   Description: Ensure that the all required tasks are resolved from trusted tasks. To exclude this rule add
>   "tasks.required_untrusted_task_found:rpms-signature-scan" to the `exclude` section of the policy configuration.
>   Solution: Make sure all required tasks in the build pipeline are resolved from trusted tasks.