### PR TITLE
ESO-160: Update 1.0.0 stage images to prod

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,10 +4,10 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # external-secrets operand image digest.
-EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:a594323b4d3ad6a739246f3767231ad2d57ca94bb1d035610d52a525b420b452
+EXTERNAL_SECRETS_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:a594323b4d3ad6a739246f3767231ad2d57ca94bb1d035610d52a525b420b452
 
 # bitwarden-sdk-server operand image digest.
-BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:0e00fb4b8fc3815e55e9c593766cfa85a34671b8401eabc488b48b66b5d1b374
+BITWARDEN_SDK_SERVER_IMAGE=registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:0e00fb4b8fc3815e55e9c593766cfa85a34671b8401eabc488b48b66b5d1b374
 
 # external-secrets-operator image digest.
-EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:72c906d2908f999e8ac26a36a882a230973d07e4ddfd0b7935ccf8b30ad90ef2
+EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:72c906d2908f999e8ac26a36a882a230973d07e4ddfd0b7935ccf8b30ad90ef2


### PR DESCRIPTION
The PR updates the 1.0.0 stage image references to prod. 

```sh
 ~/go/src/github.com/chiragkyal/external-secrets-operator-release | on release-1.0 ........................................................................................ at 12:10:22
> podman pull registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:0e00fb4b8fc3815e55e9c593766cfa85a34671b8401eabc488b48b66b5d1b374
Trying to pull registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:0e00fb4b8fc3815e55e9c593766cfa85a34671b8401eabc488b48b66b5d1b374...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:f355c5538dbed03db724d3e41eac9594b177776b86da391a446bdaa378cfa682
Copying blob sha256:a6341034914db5b05b574d1cb28c7b6a1f03d2f9da1361c4cb8a627b52b39e11
Copying config sha256:0138446b3b0cb6a1917bb5a6bef06a15622e414b23d3bcf43eacf46a8b795a96
Writing manifest to image destination
Storing signatures
0138446b3b0cb6a1917bb5a6bef06a15622e414b23d3bcf43eacf46a8b795a96

 ~/go/src/github.com/chiragkyal/external-secrets-operator-release | on release-1.0 !1 ........................................................................... took 8s | at 12:12:01
> podman pull registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:a594323b4d3ad6a739246f3767231ad2d57ca94bb1d035610d52a525b420b452
Trying to pull registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:a594323b4d3ad6a739246f3767231ad2d57ca94bb1d035610d52a525b420b452...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:f2a14482ae446838f04ab5db91be6f58ed757c08ed4d3ead5e8df8e29cdc33ee
Copying blob sha256:a6341034914db5b05b574d1cb28c7b6a1f03d2f9da1361c4cb8a627b52b39e11
Copying config sha256:2f9bc776464d0edb46307c997deafbc96b3a7064c3f418c19c121aea180c3234
Writing manifest to image destination
Storing signatures
2f9bc776464d0edb46307c997deafbc96b3a7064c3f418c19c121aea180c3234

 ~/go/src/github.com/chiragkyal/external-secrets-operator-release | on release-1.0 !1 ........................................................................... took 7s | at 12:12:58
> podman pull registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:72c906d2908f999e8ac26a36a882a230973d07e4ddfd0b7935ccf8b30ad90ef2
Trying to pull registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:72c906d2908f999e8ac26a36a882a230973d07e4ddfd0b7935ccf8b30ad90ef2...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:205c012694190a0af6f037e489f879dae980ede589f2a6bff926b187f3c85269
Copying blob sha256:a6341034914db5b05b574d1cb28c7b6a1f03d2f9da1361c4cb8a627b52b39e11
Copying config sha256:a6347c9c799668646dcce71e4423ec5d7e08bf9231a65359937f88b1bdf9a67b
Writing manifest to image destination
Storing signatures
a6347c9c799668646dcce71e4423ec5d7e08bf9231a65359937f88b1bdf9a67b

```