### PR TITLE
ESO-333: Updates the image shas to the latest stage builds

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,10 +4,10 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # external-secrets operand image digest.
-EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:77553943b093fe92250e7bb611c2b1773e19c1eb79b4d8157dc27c4f5451a5dd
+EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:685506af015863fbd548988d010b395f76b67306d7223a4960fe971e761467ea
 
 # bitwarden-sdk-server operand image digest.
-BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:b06173da39700d2aa020d0f2c9ec890fc11ccb19c1b10d86197e9bfd9cf4c4ed
+BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:c8d6027c688ab18f71381b7d5be2e6d6be323b869f0f08d403501e203ccd2db3
 
 # external-secrets-operator image digest.
-EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:cc238f45409c4d41480582ea6f036900ff02a7d5a6fb34b674924610358e33f5
+EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:074dae3205e34d005c5a1b80912898ca6b02818e5152d0a84a6dbc3f25f7e322


### PR DESCRIPTION
The PR is for the image shas to the latest stage builds

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:685506af015863fbd548988d010b395f76b67306d7223a4960fe971e761467ea | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/2e4cafeef71649d4e686fd17ba94305bfece3f37",
                    "version": "v0.20.4"
```

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:c8d6027c688ab18f71381b7d5be2e6d6be323b869f0f08d403501e203ccd2db3 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/2e4cafeef71649d4e686fd17ba94305bfece3f37",
                    "version": "v0.5.2"
```

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:074dae3205e34d005c5a1b80912898ca6b02818e5152d0a84a6dbc3f25f7e322 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/2e4cafeef71649d4e686fd17ba94305bfece3f37",
                    "version": "v1.1.0"
```