### PR TITLE
ESO-256: Updates latest operator image in the bundle

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -10,4 +10,4 @@ EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/extern
 BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:c8d6027c688ab18f71381b7d5be2e6d6be323b869f0f08d403501e203ccd2db3
 
 # external-secrets-operator image digest.
-EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:074dae3205e34d005c5a1b80912898ca6b02818e5152d0a84a6dbc3f25f7e322
+EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7e29f05b100326125d0e8dcc655f28a8a89759059a5d082f915a94c8a4648ef7


### PR DESCRIPTION
The PR is for updating the operator image to the latest in the bundle.

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7e29f05b100326125d0e8dcc655f28a8a89759059a5d082f915a94c8a4648ef7 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/a0cf763ef55b973e57b6886d59f5f22e97aa2396",
                    "version": "v1.1.0"
```