### PR TITLE
NO-JIRA: Updates catalog images to use ose-operator-registry-rhel9 public image

### DIFF
--- a/catalogs/v4.18/Containerfile
+++ b/catalogs/v4.18/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/catalogs/v4.19/Containerfile
+++ b/catalogs/v4.19/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/catalogs/v4.20/Containerfile
+++ b/catalogs/v4.20/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/catalogs/v4.21/Containerfile
+++ b/catalogs/v4.21/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.21
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/catalogs/v4.22/Containerfile
+++ b/catalogs/v4.22/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.22
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
The PR is for updating the base image in the catalog images to use `registry.redhat.io/openshift4/ose-operator-registry-rhel9`, the public version of `brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9` which is not being maintained.