### PR TITLE
ESO-261: Updates bundle with 1.1.0 prod images

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,10 +4,10 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # external-secrets operand image digest.
-EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:685506af015863fbd548988d010b395f76b67306d7223a4960fe971e761467ea
+EXTERNAL_SECRETS_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:ac9f75e7a0bccdb770f2b09a0ff044b9fe8692c4da058577cdaad54caa702c16
 
 # bitwarden-sdk-server operand image digest.
-BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:c8d6027c688ab18f71381b7d5be2e6d6be323b869f0f08d403501e203ccd2db3
+BITWARDEN_SDK_SERVER_IMAGE=registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:ff474c98280b839d3744c2590a70c7b1eac12d0e1fef373a618a4c9fb4221647
 
 # external-secrets-operator image digest.
-EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7e29f05b100326125d0e8dcc655f28a8a89759059a5d082f915a94c8a4648ef7
+EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:ffa7e19dea031e510f656145416b8cebce558d34c9a7e1fecb506f0d80b3fc3c


### PR DESCRIPTION
The PR is for updating the 1.1.0 prod image digests in the bundle.

```
$ podman inspect registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:ff474c98280b839d3744c2590a70c7b1eac12d0e1fef373a618a4c9fb4221647 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/459afe6ba712f2117a4fc7666a2be3cc5c8f3887",
                    "version": "v0.5.2"
```

```
$ podman inspect registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:ac9f75e7a0bccdb770f2b09a0ff044b9fe8692c4da058577cdaad54caa702c16 | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/459afe6ba712f2117a4fc7666a2be3cc5c8f3887",
                    "version": "v0.20.4"
```

```
$ podman inspect registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:ffa7e19dea031e510f656145416b8cebce558d34c9a7e1fecb506f0d80b3fc3c | egrep "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/459afe6ba712f2117a4fc7666a2be3cc5c8f3887",
                    "version": "v1.1.0"
```