### PR TITLE
ESO-406: Updates bundle with 1.2.0 staged images digest

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,10 +4,10 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # external-secrets operand image digest.
-EXTERNAL_SECRETS_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:ac9f75e7a0bccdb770f2b09a0ff044b9fe8692c4da058577cdaad54caa702c16
+EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:7a491bc84db1316f4889d1e610328160a76cc1509576fc6a5847cb7c0f9443f7
 
 # bitwarden-sdk-server operand image digest.
-BITWARDEN_SDK_SERVER_IMAGE=registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:ff474c98280b839d3744c2590a70c7b1eac12d0e1fef373a618a4c9fb4221647
+BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:8b5e72144defec569bcaba046ae2b5dc27bc8d9e2b2a91d3dc5a8c30e29f1075
 
 # external-secrets-operator image digest.
-EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:ffa7e19dea031e510f656145416b8cebce558d34c9a7e1fecb506f0d80b3fc3c
+EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:d1feb355a6084c3ab6ee7b8e6583329f7912a8d82210d20e191fd74cceeb1888


### PR DESCRIPTION
The PR is for updating the v1.2.0 staged images in the operator bundle.

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:d1feb355a6084c3ab6ee7b8e6583329f7912a8d82210d20e191fd74cceeb1888 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/48d2f1d528e8203c234f3b0d1ab534b6d49b63d4",
                    "version": "v1.2.0"
```

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:8b5e72144defec569bcaba046ae2b5dc27bc8d9e2b2a91d3dc5a8c30e29f1075 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/48d2f1d528e8203c234f3b0d1ab534b6d49b63d4",
                    "version": "v0.6.0"
```

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:7a491bc84db1316f4889d1e610328160a76cc1509576fc6a5847cb7c0f9443f7 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/48d2f1d528e8203c234f3b0d1ab534b6d49b63d4",
                    "version": "v2.5.0"
```