### PR TITLE
ESO-406: Updates external-secrets image build tags to include all providers

### DIFF
--- a/Containerfile.external-secrets
+++ b/Containerfile.external-secrets
@@ -5,7 +5,7 @@ WORKDIR $SOURCE_DIR
 COPY external-secrets .
 COPY external-secrets/LICENSE /licenses/
 
-ENV GO_BUILD_TAGS=strictfipsruntime,openssl
+ENV GO_BUILD_TAGS=strictfipsruntime,openssl,all_providers
 ENV GOEXPERIMENT=strictfipsruntime
 ENV CGO_ENABLED=1
 ENV GOFLAGS=""


### PR DESCRIPTION
Upstream external-secrets introduced a [feature](https://github.com/external-secrets/external-secrets/commit/1bce671b2db17a3b080157efe08bca6abb5cb039) where particular providers can be chosen to be included in the build using go build flags, which can be used to include particular set of providers or all the the providers.

For the External Secrets Operator v1.2.0, we are enabling all the providers, since we don't trim featureset downstream.