### PR TITLE
ESO-406: Updates the latest external-secrets staged image in bundle

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,7 +4,7 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # external-secrets operand image digest.
-EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:7a491bc84db1316f4889d1e610328160a76cc1509576fc6a5847cb7c0f9443f7
+EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:5c9b694462ce93a61117311496834f88954ab01178ce24a04f003748694e15f5
 
 # bitwarden-sdk-server operand image digest.
 BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:8b5e72144defec569bcaba046ae2b5dc27bc8d9e2b2a91d3dc5a8c30e29f1075


### PR DESCRIPTION
The PR is for updating the latest build of external-secrets in operator bundle.

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:5c9b694462ce93a61117311496834f88954ab01178ce24a04f003748694e15f5 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/963bbf2c2eebc268d1b242b304ba52d5d6b925a6",
                    "version": "v2.5.0"
```