### PR TITLE
ESO-481: Updates latest operator staged image in bundle

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -10,4 +10,4 @@ EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/extern
 BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:8b5e72144defec569bcaba046ae2b5dc27bc8d9e2b2a91d3dc5a8c30e29f1075
 
 # external-secrets-operator image digest.
-EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:d1feb355a6084c3ab6ee7b8e6583329f7912a8d82210d20e191fd74cceeb1888
+EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61


### PR DESCRIPTION
The PR is for updating the latest image sha of external-secrets-operator in operator bundle manifest.

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/11a270afb3157a5627520f5da09bef88f9f15739",
                    "version": "v1.2.0"
```