### PR TITLE
ESO-400: Updates the latest prod images of operator, operand in bundle

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,10 +4,10 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # external-secrets operand image digest.
-EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:5c9b694462ce93a61117311496834f88954ab01178ce24a04f003748694e15f5
+EXTERNAL_SECRETS_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:a6e93b0490998452231aa558a0f664ec30ffedf161a477c5dfa3221a16ef56f1
 
 # bitwarden-sdk-server operand image digest.
-BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:8b5e72144defec569bcaba046ae2b5dc27bc8d9e2b2a91d3dc5a8c30e29f1075
+BITWARDEN_SDK_SERVER_IMAGE=registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:960fd17b5d871f6ef69469b4f78e2d72e8540c7dc84ed1540629d0620a0892af
 
 # external-secrets-operator image digest.
-EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61
+EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:8e7a9b49e09b528d2c53d1aac86567375416a1efa38ae7e39fde5c22649015fc


### PR DESCRIPTION
The PR is for updating the prod image sha of operator and operand images in bundle manifest.

```
$ podman inspect registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:a6e93b0490998452231aa558a0f664ec30ffedf161a477c5dfa3221a16ef56f1 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/cbc61bbe03d8886c2b96ffa55b82965d91d69b84",
                    "version": "v2.5.0"
```

```
$ podman inspect registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:8e7a9b49e09b528d2c53d1aac86567375416a1efa38ae7e39fde5c22649015fc | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/cbc61bbe03d8886c2b96ffa55b82965d91d69b84",
                    "version": "v1.2.0"
```

```
$ podman inspect registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:960fd17b5d871f6ef69469b4f78e2d72e8540c7dc84ed1540629d0620a0892af | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/cbc61bbe03d8886c2b96ffa55b82965d91d69b84",
                    "version": "v0.6.0"
```