### PR TITLE
ESO-400: Updates the latest bundle images in 4.19 - 5.0 OCP catalogs

### DIFF
--- a/.tekton/external-secrets-operator-index-5-0-pull-request.yaml
+++ b/.tekton/external-secrets-operator-index-5-0-pull-request.yaml
@@ -8,8 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "./catalogs/v5.0/***".pathChanged() || ".tekton/external-secrets-operator-index-5-0-pull-request.yaml".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression:
+      event == "pull_request" && target_branch
+      == "main" && ( "catalogs/v5.0/***".pathChanged() || ".tekton/external-secrets-operator-index-5-0-pull-request.yaml".pathChanged()
       )
   labels:
     appstudio.openshift.io/application: external-secrets-operator-index-5-0

--- a/.tekton/external-secrets-operator-index-5-0-push.yaml
+++ b/.tekton/external-secrets-operator-index-5-0-push.yaml
@@ -7,8 +7,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "./catalogs/v5.0/***".pathChanged() || ".tekton/external-secrets-operator-index-5-0-push.yaml".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression:
+      event == "push" && target_branch
+      == "main" && ( "catalogs/v5.0/***".pathChanged() || ".tekton/external-secrets-operator-index-5-0-push.yaml".pathChanged()
       )
   labels:
     appstudio.openshift.io/application: external-secrets-operator-index-5-0

--- a/catalogs/v4.19/catalog/openshift-external-secrets-operator/bundle-v1.2.0.yaml
+++ b/catalogs/v4.19/catalog/openshift-external-secrets-operator/bundle-v1.2.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:b7413b7dda1dfaca20e09f456bca29f5e7f699d4e6bd1d9137e818efaa8e8955
+image: registry.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:502364a848394debef14f079a5a84e3a472861fc802575a0bc662bebb832dc26
 name: openshift-external-secrets-operator.v1.2.0
 package: openshift-external-secrets-operator
 properties:
@@ -367,8 +367,8 @@ properties:
       capabilities: Basic Install
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61
-      createdAt: 2026-06-24T10:49:33
+      containerImage: registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:c8086753d720b76fef68ce4983912d50801c3373b25611fa42671d8438b2d54c
+      createdAt: 2026-07-08T10:39:32
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -594,12 +594,12 @@ properties:
     provider:
       name: Red Hat, Inc.
 relatedImages:
-- image: registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:8b5e72144defec569bcaba046ae2b5dc27bc8d9e2b2a91d3dc5a8c30e29f1075
+- image: registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:c81758042b236476f73e9a3187adb0cd3f25f13aedf8e13a9153ef26abc0b97c
   name: bitwarden-sdk-server
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:b7413b7dda1dfaca20e09f456bca29f5e7f699d4e6bd1d9137e818efaa8e8955
+- image: registry.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:502364a848394debef14f079a5a84e3a472861fc802575a0bc662bebb832dc26
   name: ""
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61
+- image: registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:c8086753d720b76fef68ce4983912d50801c3373b25611fa42671d8438b2d54c
   name: ""
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:5c9b694462ce93a61117311496834f88954ab01178ce24a04f003748694e15f5
+- image: registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:7774aa4de3ce24f5d2ff73224e25244fab1e7fefee14a66e7a807cab705e7ae8
   name: external-secrets
 schema: olm.bundle

--- a/catalogs/v4.19/catalog/openshift-external-secrets-operator/channel.yaml
+++ b/catalogs/v4.19/catalog/openshift-external-secrets-operator/channel.yaml
@@ -24,9 +24,9 @@ package: openshift-external-secrets-operator
 schema: olm.channel
 ---
 entries:
-  - name: openshift-external-secrets-operator.v1.2.0
-    replaces: external-secrets-operator.v1.1.0
-    skipRange: '>=1.1.0 <1.2.0'
+- name: openshift-external-secrets-operator.v1.2.0
+  replaces: openshift-external-secrets-operator.v1.1.0
+  skipRange: '>=1.1.0 <1.2.0'
 name: stable-v1.2
 package: openshift-external-secrets-operator
 schema: olm.channel

--- a/catalogs/v4.20/catalog/openshift-external-secrets-operator/bundle-v1.2.0.yaml
+++ b/catalogs/v4.20/catalog/openshift-external-secrets-operator/bundle-v1.2.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:b7413b7dda1dfaca20e09f456bca29f5e7f699d4e6bd1d9137e818efaa8e8955
+image: registry.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:502364a848394debef14f079a5a84e3a472861fc802575a0bc662bebb832dc26
 name: openshift-external-secrets-operator.v1.2.0
 package: openshift-external-secrets-operator
 properties:
@@ -367,8 +367,8 @@ properties:
       capabilities: Basic Install
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61
-      createdAt: 2026-06-24T10:49:33
+      containerImage: registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:c8086753d720b76fef68ce4983912d50801c3373b25611fa42671d8438b2d54c
+      createdAt: 2026-07-08T10:39:32
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -594,12 +594,12 @@ properties:
     provider:
       name: Red Hat, Inc.
 relatedImages:
-- image: registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:8b5e72144defec569bcaba046ae2b5dc27bc8d9e2b2a91d3dc5a8c30e29f1075
+- image: registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:c81758042b236476f73e9a3187adb0cd3f25f13aedf8e13a9153ef26abc0b97c
   name: bitwarden-sdk-server
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:b7413b7dda1dfaca20e09f456bca29f5e7f699d4e6bd1d9137e818efaa8e8955
+- image: registry.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:502364a848394debef14f079a5a84e3a472861fc802575a0bc662bebb832dc26
   name: ""
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61
+- image: registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:c8086753d720b76fef68ce4983912d50801c3373b25611fa42671d8438b2d54c
   name: ""
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:5c9b694462ce93a61117311496834f88954ab01178ce24a04f003748694e15f5
+- image: registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:7774aa4de3ce24f5d2ff73224e25244fab1e7fefee14a66e7a807cab705e7ae8
   name: external-secrets
 schema: olm.bundle

--- a/catalogs/v4.20/catalog/openshift-external-secrets-operator/channel.yaml
+++ b/catalogs/v4.20/catalog/openshift-external-secrets-operator/channel.yaml
@@ -28,9 +28,9 @@ package: openshift-external-secrets-operator
 schema: olm.channel
 ---
 entries:
-  - name: openshift-external-secrets-operator.v1.2.0
-    replaces: external-secrets-operator.v1.1.0
-    skipRange: '>=1.1.0 <1.2.0'
+- name: openshift-external-secrets-operator.v1.2.0
+  replaces: openshift-external-secrets-operator.v1.1.0
+  skipRange: '>=1.1.0 <1.2.0'
 name: stable-v1.2
 package: openshift-external-secrets-operator
 schema: olm.channel

--- a/catalogs/v4.21/catalog/openshift-external-secrets-operator/bundle-v1.2.0.yaml
+++ b/catalogs/v4.21/catalog/openshift-external-secrets-operator/bundle-v1.2.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:b7413b7dda1dfaca20e09f456bca29f5e7f699d4e6bd1d9137e818efaa8e8955
+image: registry.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:502364a848394debef14f079a5a84e3a472861fc802575a0bc662bebb832dc26
 name: openshift-external-secrets-operator.v1.2.0
 package: openshift-external-secrets-operator
 properties:
@@ -367,8 +367,8 @@ properties:
       capabilities: Basic Install
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61
-      createdAt: 2026-06-24T10:49:33
+      containerImage: registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:c8086753d720b76fef68ce4983912d50801c3373b25611fa42671d8438b2d54c
+      createdAt: 2026-07-08T10:39:32
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -594,12 +594,12 @@ properties:
     provider:
       name: Red Hat, Inc.
 relatedImages:
-- image: registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:8b5e72144defec569bcaba046ae2b5dc27bc8d9e2b2a91d3dc5a8c30e29f1075
+- image: registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:c81758042b236476f73e9a3187adb0cd3f25f13aedf8e13a9153ef26abc0b97c
   name: bitwarden-sdk-server
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:b7413b7dda1dfaca20e09f456bca29f5e7f699d4e6bd1d9137e818efaa8e8955
+- image: registry.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:502364a848394debef14f079a5a84e3a472861fc802575a0bc662bebb832dc26
   name: ""
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61
+- image: registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:c8086753d720b76fef68ce4983912d50801c3373b25611fa42671d8438b2d54c
   name: ""
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:5c9b694462ce93a61117311496834f88954ab01178ce24a04f003748694e15f5
+- image: registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:7774aa4de3ce24f5d2ff73224e25244fab1e7fefee14a66e7a807cab705e7ae8
   name: external-secrets
 schema: olm.bundle

--- a/catalogs/v4.21/catalog/openshift-external-secrets-operator/channel.yaml
+++ b/catalogs/v4.21/catalog/openshift-external-secrets-operator/channel.yaml
@@ -28,9 +28,9 @@ package: openshift-external-secrets-operator
 schema: olm.channel
 ---
 entries:
-  - name: openshift-external-secrets-operator.v1.2.0
-    replaces: external-secrets-operator.v1.1.0
-    skipRange: '>=1.1.0 <1.2.0'
+- name: openshift-external-secrets-operator.v1.2.0
+  replaces: openshift-external-secrets-operator.v1.1.0
+  skipRange: '>=1.1.0 <1.2.0'
 name: stable-v1.2
 package: openshift-external-secrets-operator
 schema: olm.channel

--- a/catalogs/v4.22/catalog/openshift-external-secrets-operator/bundle-v1.2.0.yaml
+++ b/catalogs/v4.22/catalog/openshift-external-secrets-operator/bundle-v1.2.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:b7413b7dda1dfaca20e09f456bca29f5e7f699d4e6bd1d9137e818efaa8e8955
+image: registry.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:502364a848394debef14f079a5a84e3a472861fc802575a0bc662bebb832dc26
 name: openshift-external-secrets-operator.v1.2.0
 package: openshift-external-secrets-operator
 properties:
@@ -367,8 +367,8 @@ properties:
       capabilities: Basic Install
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61
-      createdAt: 2026-06-24T10:49:33
+      containerImage: registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:c8086753d720b76fef68ce4983912d50801c3373b25611fa42671d8438b2d54c
+      createdAt: 2026-07-08T10:39:32
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -594,12 +594,12 @@ properties:
     provider:
       name: Red Hat, Inc.
 relatedImages:
-- image: registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:8b5e72144defec569bcaba046ae2b5dc27bc8d9e2b2a91d3dc5a8c30e29f1075
+- image: registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:c81758042b236476f73e9a3187adb0cd3f25f13aedf8e13a9153ef26abc0b97c
   name: bitwarden-sdk-server
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:b7413b7dda1dfaca20e09f456bca29f5e7f699d4e6bd1d9137e818efaa8e8955
+- image: registry.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:502364a848394debef14f079a5a84e3a472861fc802575a0bc662bebb832dc26
   name: ""
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61
+- image: registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:c8086753d720b76fef68ce4983912d50801c3373b25611fa42671d8438b2d54c
   name: ""
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:5c9b694462ce93a61117311496834f88954ab01178ce24a04f003748694e15f5
+- image: registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:7774aa4de3ce24f5d2ff73224e25244fab1e7fefee14a66e7a807cab705e7ae8
   name: external-secrets
 schema: olm.bundle

--- a/catalogs/v4.22/catalog/openshift-external-secrets-operator/channel.yaml
+++ b/catalogs/v4.22/catalog/openshift-external-secrets-operator/channel.yaml
@@ -28,9 +28,9 @@ package: openshift-external-secrets-operator
 schema: olm.channel
 ---
 entries:
-  - name: openshift-external-secrets-operator.v1.2.0
-    replaces: external-secrets-operator.v1.1.0
-    skipRange: '>=1.1.0 <1.2.0'
+- name: openshift-external-secrets-operator.v1.2.0
+  replaces: openshift-external-secrets-operator.v1.1.0
+  skipRange: '>=1.1.0 <1.2.0'
 name: stable-v1.2
 package: openshift-external-secrets-operator
 schema: olm.channel

--- a/catalogs/v5.0/catalog/openshift-external-secrets-operator/bundle-v1.2.0.yaml
+++ b/catalogs/v5.0/catalog/openshift-external-secrets-operator/bundle-v1.2.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:b7413b7dda1dfaca20e09f456bca29f5e7f699d4e6bd1d9137e818efaa8e8955
+image: registry.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:502364a848394debef14f079a5a84e3a472861fc802575a0bc662bebb832dc26
 name: openshift-external-secrets-operator.v1.2.0
 package: openshift-external-secrets-operator
 properties:
@@ -367,8 +367,8 @@ properties:
       capabilities: Basic Install
       categories: Security
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61
-      createdAt: 2026-06-24T10:49:33
+      containerImage: registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:c8086753d720b76fef68ce4983912d50801c3373b25611fa42671d8438b2d54c
+      createdAt: 2026-07-08T10:39:32
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "false"
@@ -594,12 +594,12 @@ properties:
     provider:
       name: Red Hat, Inc.
 relatedImages:
-- image: registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:8b5e72144defec569bcaba046ae2b5dc27bc8d9e2b2a91d3dc5a8c30e29f1075
+- image: registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:c81758042b236476f73e9a3187adb0cd3f25f13aedf8e13a9153ef26abc0b97c
   name: bitwarden-sdk-server
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:b7413b7dda1dfaca20e09f456bca29f5e7f699d4e6bd1d9137e818efaa8e8955
+- image: registry.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:502364a848394debef14f079a5a84e3a472861fc802575a0bc662bebb832dc26
   name: ""
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:fe6ad2eef8ed0ec4d49f0376204cda359e7f9b2862a78b9aa6602c90a68dab61
+- image: registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:c8086753d720b76fef68ce4983912d50801c3373b25611fa42671d8438b2d54c
   name: ""
-- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:5c9b694462ce93a61117311496834f88954ab01178ce24a04f003748694e15f5
+- image: registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:7774aa4de3ce24f5d2ff73224e25244fab1e7fefee14a66e7a807cab705e7ae8
   name: external-secrets
 schema: olm.bundle

--- a/catalogs/v5.0/catalog/openshift-external-secrets-operator/channel.yaml
+++ b/catalogs/v5.0/catalog/openshift-external-secrets-operator/channel.yaml
@@ -1,7 +1,7 @@
 ---
 entries:
 - name: openshift-external-secrets-operator.v1.2.0
-  replaces: external-secrets-operator.v1.1.0
+  replaces: openshift-external-secrets-operator.v1.1.0
   skipRange: '>=1.1.0 <1.2.0'
 name: stable-v1
 package: openshift-external-secrets-operator
@@ -9,7 +9,7 @@ schema: olm.channel
 ---
 entries:
 - name: openshift-external-secrets-operator.v1.2.0
-  replaces: external-secrets-operator.v1.1.0
+  replaces: openshift-external-secrets-operator.v1.1.0
   skipRange: '>=1.1.0 <1.2.0'
 name: stable-v1.2
 package: openshift-external-secrets-operator


### PR DESCRIPTION
The PR is for updating the v1.2.0 prod bundle image in OCP 4.19 - 5.0 OCP catalogs.

```
$ podman inspect registry.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:502364a848394debef14f079a5a84e3a472861fc802575a0bc662bebb832dc26 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/d290f41a2a4f25703189dc44ab7389930f9493c2",
                    "version": "v1.2.0"
```