### PR TITLE
[main] NO-JIRA: Enable auto-merge for konflux/mintmaker bot created PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,8 @@
 					"pin",
 					"digest"
 				],
-				"automerge": true
+				"automerge": true,
+				"addLabels": ["/approve", "/lgtm"]
 			}
 		]
 	},
@@ -30,7 +31,8 @@
 		"packageRules": [
 			{
 				"matchFileNames": ["Containerfile.*"],
-				"automerge": true
+				"automerge": true,
+				"addLabels": ["/approve", "/lgtm"]
 			}
 		]
 	},


### PR DESCRIPTION
The PR is for enabling the auto-merge option for konflux/mintmaker bot created PRs, specifically for image sha updates in tekton configs and Containerfiles.