### PR TITLE
[release-1.2] NO-JIRA: Enable auto-merge for konflux/mintmaker bot created PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,26 +11,6 @@
 	"rebaseLabel": "needs-rebase",
 	"rebaseWhen": "behind-base-branch",
 	"recreateWhen": "always",
-	"packageRules": [
-		{
-			"description": "Update RHEL UBI base images monthly (fetch latest tag digest)",
-			"matchDatasources": ["docker"],
-			"matchPackageNames": ["registry.access.redhat.com/ubi9/ubi-minimal"],
-			"schedule": ["on the first day of the month"],
-			"pinDigests": true,
-			"matchCurrentValue": "latest",
-			"commitMessageTopic": "Updates RHEL UBI base image digest",
-			"prBodyNotes": [
-				"**Base Image Update Info:**",
-				"- Registry: `registry.access.redhat.com`",
-				"- Image: `ubi9/ubi-minimal`",
-				"- Tag: `latest`",
-				"- Previous digest: `{{currentDigestShort}}`",
-				"- New digest: `{{newDigestShort}}`",
-				""
-			]
-		}
-	],
 	"tekton": {
 		"enabled": true,
 		"packageRules": [
@@ -41,7 +21,8 @@
 					"pin",
 					"digest"
 				],
-				"automerge": true
+				"automerge": true,
+				"addLabels": ["/approve", "/lgtm"]
 			}
 		]
 	},
@@ -50,7 +31,8 @@
 		"packageRules": [
 			{
 				"matchFileNames": ["Containerfile.*"],
-				"automerge": true
+				"automerge": true,
+				"addLabels": ["/approve", "/lgtm"]
 			}
 		]
 	},


### PR DESCRIPTION
The PR is for enabling the auto-merge option for konflux/mintmaker bot created PRs, specifically for image sha updates in tekton configs and Containerfiles.