### PR TITLE
ESO-400: Updates the containerfiles to use go-toolset builder image

### DIFF
--- a/Containerfile.bitwarden-sdk-server
+++ b/Containerfile.bitwarden-sdk-server
@@ -3,8 +3,9 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 ARG SOURCE_DIR="/opt/app-root/src/bitwarden-sdk-server"
 WORKDIR $SOURCE_DIR
 
+RUN mkdir bin
 COPY bitwarden-sdk-server .
-COPY bitwarden-sdk-server/LICENSE /tmp/licenses/
+COPY bitwarden-sdk-server/LICENSE /opt/app-root/licenses/
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
 ENV GOEXPERIMENT=strictfipsruntime
@@ -25,11 +26,11 @@ ARG RELEASE_VERSION
 ARG COMMIT_SHA
 ## github URL of the external-secrets-bitwarden-sdk-server source repository.
 ARG SOURCE_URL
-ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets-bitwarden-sdk-server"
+ARG SOURCE_DIR="/opt/app-root/src/bitwarden-sdk-server"
 
 COPY --from=builder $SOURCE_DIR/bin/bitwarden-sdk-server /bin/bitwarden-sdk-server
 COPY --from=builder --chown=65534:65534 $SOURCE_DIR/state /state
-COPY --from=builder /tmp/licenses /licenses
+COPY --from=builder /opt/app-root/licenses /licenses
 
 EXPOSE 9998
 ENV CGO_ENABLED=1

--- a/Containerfile.bitwarden-sdk-server
+++ b/Containerfile.bitwarden-sdk-server
@@ -1,7 +1,11 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 AS builder
-ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets-bitwarden-sdk-server"
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
+ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets-bitwarden-sdk-server"
 WORKDIR $SOURCE_DIR
+# rhel9/go-toolset runs as a non-root user by default; switch to root in this
+# builder stage so we can build binaries in place.
+USER 0
+
 COPY bitwarden-sdk-server .
 COPY bitwarden-sdk-server/LICENSE /licenses/
 
@@ -11,7 +15,9 @@ ENV CGO_ENABLED=1
 ENV GOFLAGS=""
 ENV OPENSHIFT_CI=1
 
-RUN mkdir state && CGO_LDFLAGS="-lm" go build -a -ldflags '-linkmode external -extldflags "-static -Wl,-unresolved-symbols=ignore-all"' -tags ${GO_BUILD_TAGS} -o bin/bitwarden-sdk-server main.go
+RUN mkdir state && CGO_LDFLAGS="-lm" go build -a \
+  -ldflags '-linkmode external -extldflags "-Wl,-unresolved-symbols=ignore-all"' \
+  -tags ${GO_BUILD_TAGS} -o bin/bitwarden-sdk-server main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:463cae32c6f6f5594b11a5c22de275016bd8545ce58a6373388e8b24f13fc15c
 

--- a/Containerfile.bitwarden-sdk-server
+++ b/Containerfile.bitwarden-sdk-server
@@ -1,13 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
-ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets-bitwarden-sdk-server"
+ARG SOURCE_DIR="/opt/app-root/src/bitwarden-sdk-server"
 WORKDIR $SOURCE_DIR
-# rhel9/go-toolset runs as a non-root user by default; switch to root in this
-# builder stage so we can build binaries in place.
-USER 0
 
 COPY bitwarden-sdk-server .
-COPY bitwarden-sdk-server/LICENSE /licenses/
+COPY bitwarden-sdk-server/LICENSE /tmp/licenses/
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
 ENV GOEXPERIMENT=strictfipsruntime
@@ -32,7 +29,7 @@ ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets-bitwarden-sdk-serv
 
 COPY --from=builder $SOURCE_DIR/bin/bitwarden-sdk-server /bin/bitwarden-sdk-server
 COPY --from=builder --chown=65534:65534 $SOURCE_DIR/state /state
-COPY --from=builder /licenses /licenses
+COPY --from=builder /tmp/licenses /licenses
 
 EXPOSE 9998
 ENV CGO_ENABLED=1

--- a/Containerfile.external-secrets
+++ b/Containerfile.external-secrets
@@ -3,8 +3,9 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 ARG SOURCE_DIR="/opt/app-root/src/external-secrets"
 WORKDIR $SOURCE_DIR
 
+RUN mkdir bin
 COPY external-secrets .
-COPY external-secrets/LICENSE /tmp/licenses/
+COPY external-secrets/LICENSE /opt/app-root/licenses/
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl,all_providers
 ENV GOEXPERIMENT=strictfipsruntime
@@ -22,10 +23,10 @@ ARG RELEASE_VERSION
 ARG COMMIT_SHA
 ## github URL of the external-secrets source repository.
 ARG SOURCE_URL
-ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets"
+ARG SOURCE_DIR="/opt/app-root/src/external-secrets"
 
 COPY --from=builder $SOURCE_DIR/bin/external-secrets /bin/external-secrets
-COPY --from=builder /tmp/licenses /licenses
+COPY --from=builder /opt/app-root/licenses /licenses
 
 USER 65534:65534
 

--- a/Containerfile.external-secrets
+++ b/Containerfile.external-secrets
@@ -1,7 +1,11 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 AS builder
-ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets"
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
+ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets"
 WORKDIR $SOURCE_DIR
+# rhel9/go-toolset runs as a non-root user by default; switch to root in this
+# builder stage so we can build binaries in place.
+USER 0
+
 COPY external-secrets .
 COPY external-secrets/LICENSE /licenses/
 

--- a/Containerfile.external-secrets
+++ b/Containerfile.external-secrets
@@ -1,13 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
-ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets"
+ARG SOURCE_DIR="/opt/app-root/src/external-secrets"
 WORKDIR $SOURCE_DIR
-# rhel9/go-toolset runs as a non-root user by default; switch to root in this
-# builder stage so we can build binaries in place.
-USER 0
 
 COPY external-secrets .
-COPY external-secrets/LICENSE /licenses/
+COPY external-secrets/LICENSE /tmp/licenses/
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl,all_providers
 ENV GOEXPERIMENT=strictfipsruntime
@@ -28,7 +25,7 @@ ARG SOURCE_URL
 ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets"
 
 COPY --from=builder $SOURCE_DIR/bin/external-secrets /bin/external-secrets
-COPY --from=builder /licenses /licenses
+COPY --from=builder /tmp/licenses /licenses
 
 USER 65534:65534
 

--- a/Containerfile.external-secrets-operator
+++ b/Containerfile.external-secrets-operator
@@ -15,7 +15,7 @@ WORKDIR $SOURCE_DIR
 USER 0
 
 COPY external-secrets-operator .
-COPY external-secrets-operator/LICENSE /licenses/
+COPY external-secrets-operator/LICENSE /tmp/licenses/
 
 RUN IMG_VERSION=${RELEASE_VERSION#v} SOURCE_GIT_COMMIT=${COMMIT_SHA} make build
 
@@ -27,7 +27,7 @@ ARG SOURCE_URL
 ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets-operator"
 
 COPY --from=builder $SOURCE_DIR/bin/external-secrets-operator /bin/external-secrets-operator
-COPY --from=builder /licenses /licenses
+COPY --from=builder /tmp/licenses /licenses
 
 USER 65534:65534
 

--- a/Containerfile.external-secrets-operator
+++ b/Containerfile.external-secrets-operator
@@ -8,26 +8,24 @@ ARG COMMIT_SHA
 ## GitHub URL of the external-secrets-operator source repository.
 ARG SOURCE_URL
 ## The location where the source code is stored.
-ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets-operator"
+ARG SOURCE_DIR="/opt/app-root/src/external-secrets-operator"
 WORKDIR $SOURCE_DIR
-# rhel9/go-toolset runs as a non-root user by default; switch to root in this
-# builder stage so we can build binaries in place.
-USER 0
 
+RUN mkdir bin
 COPY external-secrets-operator .
-COPY external-secrets-operator/LICENSE /tmp/licenses/
+COPY external-secrets-operator/LICENSE /opt/app-root/licenses/
 
-RUN IMG_VERSION=${RELEASE_VERSION#v} SOURCE_GIT_COMMIT=${COMMIT_SHA} make build
+RUN IMG_VERSION=${RELEASE_VERSION#v} SOURCE_GIT_COMMIT=${COMMIT_SHA} make build-operator
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:463cae32c6f6f5594b11a5c22de275016bd8545ce58a6373388e8b24f13fc15c
 
 ARG RELEASE_VERSION
 ARG COMMIT_SHA
 ARG SOURCE_URL
-ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets-operator"
+ARG SOURCE_DIR="/opt/app-root/src/external-secrets-operator"
 
 COPY --from=builder $SOURCE_DIR/bin/external-secrets-operator /bin/external-secrets-operator
-COPY --from=builder /tmp/licenses /licenses
+COPY --from=builder /opt/app-root/licenses /licenses
 
 USER 65534:65534
 

--- a/Containerfile.external-secrets-operator
+++ b/Containerfile.external-secrets-operator
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 # Values for below ARGs will passed from tekton configs for konflux builds.
 ## Release version of the external-secrets-operator source code used in the build.
@@ -9,8 +9,11 @@ ARG COMMIT_SHA
 ARG SOURCE_URL
 ## The location where the source code is stored.
 ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets-operator"
-
 WORKDIR $SOURCE_DIR
+# rhel9/go-toolset runs as a non-root user by default; switch to root in this
+# builder stage so we can build binaries in place.
+USER 0
+
 COPY external-secrets-operator .
 COPY external-secrets-operator/LICENSE /licenses/
 

--- a/Containerfile.external-secrets-operator.bundle
+++ b/Containerfile.external-secrets-operator.bundle
@@ -1,21 +1,13 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
-WORKDIR /
-# rhel9/go-toolset runs as a non-root user by default; switch to root in this
-# builder stage so we can install tools and modify bundle manifests in place.
-USER 0
+ARG SOURCE_DIR="/opt/app-root/src/external-secrets-operator"
+WORKDIR $SOURCE_DIR
 
-COPY external-secrets-operator/bundle/manifests /manifests
-COPY external-secrets-operator/bundle/metadata /metadata
-COPY external-secrets-operator/bundle/tests/scorecard /tests/scorecard
-COPY external-secrets-operator/LICENSE /licenses/
-COPY images_digest.conf /images_digest.conf
-WORKDIR /opt/app-root
-
+RUN mkdir manifests metadata bin
 COPY external-secrets-operator/bundle/manifests manifests
 COPY external-secrets-operator/bundle/metadata metadata
 COPY external-secrets-operator/bundle/tests/scorecard tests/scorecard
-COPY external-secrets-operator/LICENSE /tmp/licenses/
+COPY external-secrets-operator/LICENSE /opt/app-root/licenses/
 COPY images_digest.conf images_digest.conf
 COPY --chmod=0550 hack/bundle/render_templates.sh render_templates.sh
 
@@ -24,17 +16,16 @@ ENV GOEXPERIMENT=strictfipsruntime
 ENV CGO_ENABLED=1
 ENV GOFLAGS=""
 
-COPY tools.go go.mod go.sum /
-RUN go build -o /usr/bin/yq github.com/mikefarah/yq/v4 && chmod +x /usr/bin/yq
-COPY tools.go go.mod go.sum ./
-RUN go build -o ./yq github.com/mikefarah/yq/v4 && chmod +x ./yq
-RUN PATH=$PATH:/opt/app-root ./render_templates.sh manifests metadata images_digest.conf
+COPY tools.go go.mod go.sum .
+RUN go build -o bin/yq github.com/mikefarah/yq/v4 && chmod +x bin/yq
+RUN PATH=$PATH:$SOURCE_DIR/bin ./render_templates.sh manifests metadata images_digest.conf
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:463cae32c6f6f5594b11a5c22de275016bd8545ce58a6373388e8b24f13fc15c
 
 ARG RELEASE_VERSION
 ARG COMMIT_SHA
 ARG SOURCE_URL
+ARG SOURCE_DIR="/opt/app-root/src/external-secrets-operator"
 
 # Core bundle labels.
 LABEL com.redhat.component="external-secrets-operator-bundle-container" \
@@ -72,12 +63,9 @@ LABEL com.redhat.component="external-secrets-operator-bundle-container" \
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1 \
       operators.operatorframework.io.test.config.v1=tests/scorecard/
 
-COPY --from=builder /manifests /manifests
-COPY --from=builder /metadata /metadata
-COPY --from=builder /tests/scorecard /tests/scorecard
-COPY --from=builder /opt/app-root/manifests /manifests
-COPY --from=builder /opt/app-root/metadata /metadata
-COPY --from=builder /opt/app-root/tests/scorecard /tests/scorecard
-COPY --from=builder /tmp/licenses /licenses
+COPY --from=builder $SOURCE_DIR/manifests /manifests
+COPY --from=builder $SOURCE_DIR/metadata /metadata
+COPY --from=builder $SOURCE_DIR/tests/scorecard /tests/scorecard
+COPY --from=builder /opt/app-root/licenses /licenses
 
 USER 65534:65534

--- a/Containerfile.external-secrets-operator.bundle
+++ b/Containerfile.external-secrets-operator.bundle
@@ -10,7 +10,14 @@ COPY external-secrets-operator/bundle/metadata /metadata
 COPY external-secrets-operator/bundle/tests/scorecard /tests/scorecard
 COPY external-secrets-operator/LICENSE /licenses/
 COPY images_digest.conf /images_digest.conf
-COPY --chmod=0550 hack/bundle/render_templates.sh /render_templates.sh
+WORKDIR /opt/app-root
+
+COPY external-secrets-operator/bundle/manifests manifests
+COPY external-secrets-operator/bundle/metadata metadata
+COPY external-secrets-operator/bundle/tests/scorecard tests/scorecard
+COPY external-secrets-operator/LICENSE /tmp/licenses/
+COPY images_digest.conf images_digest.conf
+COPY --chmod=0550 hack/bundle/render_templates.sh render_templates.sh
 
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
 ENV GOEXPERIMENT=strictfipsruntime
@@ -19,7 +26,9 @@ ENV GOFLAGS=""
 
 COPY tools.go go.mod go.sum /
 RUN go build -o /usr/bin/yq github.com/mikefarah/yq/v4 && chmod +x /usr/bin/yq
-RUN ./render_templates.sh /manifests /metadata /images_digest.conf
+COPY tools.go go.mod go.sum ./
+RUN go build -o ./yq github.com/mikefarah/yq/v4 && chmod +x ./yq
+RUN PATH=$PATH:/opt/app-root ./render_templates.sh manifests metadata images_digest.conf
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:463cae32c6f6f5594b11a5c22de275016bd8545ce58a6373388e8b24f13fc15c
 
@@ -66,6 +75,9 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1 \
 COPY --from=builder /manifests /manifests
 COPY --from=builder /metadata /metadata
 COPY --from=builder /tests/scorecard /tests/scorecard
-COPY --from=builder /licenses /licenses
+COPY --from=builder /opt/app-root/manifests /manifests
+COPY --from=builder /opt/app-root/metadata /metadata
+COPY --from=builder /opt/app-root/tests/scorecard /tests/scorecard
+COPY --from=builder /tmp/licenses /licenses
 
 USER 65534:65534

--- a/Containerfile.external-secrets-operator.bundle
+++ b/Containerfile.external-secrets-operator.bundle
@@ -1,4 +1,9 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
+
+WORKDIR /
+# rhel9/go-toolset runs as a non-root user by default; switch to root in this
+# builder stage so we can install tools and modify bundle manifests in place.
+USER 0
 
 COPY external-secrets-operator/bundle/manifests /manifests
 COPY external-secrets-operator/bundle/metadata /metadata

--- a/hack/bundle/render_templates.sh
+++ b/hack/bundle/render_templates.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -o nounset
+set -o pipefail
+set -o errexit
 set -x
 
 declare MANIFESTS_DIR


### PR DESCRIPTION
The PR is below changes
- The Containerfiles are updated to use `registry.access.redhat.com/ubi9/go-toolset`, instead of `brew.registry.redhat.io/rh-osbs/openshift-golang-builder` which requires additional credentials configuration and also because go-toolset receives the latest updates at faster rate.
- The external-secrets-operator submodule is update to the latest commit.