### PR TITLE
ESO-400: Updates the latest prod images of operator, operand in bundle

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,10 +4,10 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # external-secrets operand image digest.
-EXTERNAL_SECRETS_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:a6e93b0490998452231aa558a0f664ec30ffedf161a477c5dfa3221a16ef56f1
+EXTERNAL_SECRETS_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:7774aa4de3ce24f5d2ff73224e25244fab1e7fefee14a66e7a807cab705e7ae8
 
 # bitwarden-sdk-server operand image digest.
-BITWARDEN_SDK_SERVER_IMAGE=registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:960fd17b5d871f6ef69469b4f78e2d72e8540c7dc84ed1540629d0620a0892af
+BITWARDEN_SDK_SERVER_IMAGE=registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:c81758042b236476f73e9a3187adb0cd3f25f13aedf8e13a9153ef26abc0b97c
 
 # external-secrets-operator image digest.
-EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:8e7a9b49e09b528d2c53d1aac86567375416a1efa38ae7e39fde5c22649015fc
+EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:c8086753d720b76fef68ce4983912d50801c3373b25611fa42671d8438b2d54c


### PR DESCRIPTION
The PR is for updating the latest prod image sha's of operator and operand in the bundle.

```
$ podman inspect registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:7774aa4de3ce24f5d2ff73224e25244fab1e7fefee14a66e7a807cab705e7ae8 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/acbb8952eb70f7b4f9c67907e085ed58630909a7",
                    "version": "v2.5.0"
```

```
$ podman inspect registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:c81758042b236476f73e9a3187adb0cd3f25f13aedf8e13a9153ef26abc0b97c | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/acbb8952eb70f7b4f9c67907e085ed58630909a7",
                    "version": "v0.6.0"
```

```
$ podman inspect registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:c8086753d720b76fef68ce4983912d50801c3373b25611fa42671d8438b2d54c | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/acbb8952eb70f7b4f9c67907e085ed58630909a7",
                    "version": "v1.2.0"
```