### PR TITLE
[release-1.2] NO-JIRA: Updates renovate auto-merge labels

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
 					"digest"
 				],
 				"automerge": true,
-				"addLabels": ["/approve", "/lgtm"]
+				"addLabels": ["approved", "lgtm"]
 			}
 		]
 	},
@@ -32,7 +32,7 @@
 			{
 				"matchFileNames": ["Containerfile.*"],
 				"automerge": true,
-				"addLabels": ["/approve", "/lgtm"]
+				"addLabels": ["approved", "lgtm"]
 			}
 		]
 	},


### PR DESCRIPTION
The PR is for the updating the labels used for enabling the automerge for PRs created by the mintmaker. Earlier labels add an extra slash as the beginning, which is not required.