### PR TITLE
[release-1.2] ESO-569, ESO-570: Pin hack tools and harden Renovate

### DIFF
--- a/hack/containerfile-linter.sh
+++ b/hack/containerfile-linter.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091 # sourced file path is runtime-resolved
+source "$(dirname "${BASH_SOURCE[0]}")/tool-images.sh"
+
 declare -a CONTAINERFILES
 declare -a EXTERNAL_SECRETS_OPERATOR_CONTAINERFILES
 
 linter()
 {
+	require_image_digest "${HADOLINT_IMAGE}" "HADOLINT_IMAGE"
 	containerfiles=("$@")
 	for containerfile in "${containerfiles[@]}"; do
 		if [[ ! -f "${containerfile}" ]]; then
@@ -12,7 +16,7 @@ linter()
 			exit 1
 		fi
 		echo "[$(date)] -- INFO  -- running linter on ${containerfile}"
-		if ! podman run --rm -i -e "HADOLINT_FAILURE_THRESHOLD=error" ghcr.io/hadolint/hadolint < "${containerfile}" ; then
+		if ! podman run --rm -i -e "HADOLINT_FAILURE_THRESHOLD=error" "${HADOLINT_IMAGE}" < "${containerfile}" ; then
 			exit 1
 		fi
 	done

--- a/hack/renovate-config-validator.sh
+++ b/hack/renovate-config-validator.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091 # sourced file path is runtime-resolved
+source "$(dirname "${BASH_SOURCE[0]}")/tool-images.sh"
+
 validate_config()
 {
-	if ! podman run -e "LOG_LEVEL=debug" --rm -v "./renovate.json:/tmp/validate/renovate.json:Z" -w /tmp/validate ghcr.io/renovatebot/renovate \
+	require_image_digest "${RENOVATE_IMAGE}" "RENOVATE_IMAGE"
+	if ! podman run -e "LOG_LEVEL=debug" --rm -v "./renovate.json:/tmp/validate/renovate.json:Z" -w /tmp/validate \
+		"${RENOVATE_IMAGE}" \
 		renovate-config-validator --strict /tmp/validate/renovate.json; then
 		exit 1
 	fi

--- a/hack/shell-scripts-linter.sh
+++ b/hack/shell-scripts-linter.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091 # sourced file path is runtime-resolved
+source "$(dirname "${BASH_SOURCE[0]}")/tool-images.sh"
+
 verify_script()
 {
+  require_image_digest "${SHELLCHECK_IMAGE}" "SHELLCHECK_IMAGE"
   if ! find . -type f -name '*.sh' '!' -path './external-secrets/*' '!' -path './external-secrets-operator/*' '!' -path './bitwarden-sdk-server/*' \
 		-printf "[$(date)] -- INFO  -- checking file %p\n" \
-		-exec podman run --rm -v "$PWD:/mnt:Z" -w /mnt docker.io/koalaman/shellcheck:stable '{}' + ; then
+		-exec podman run --rm -v "$PWD:/mnt:Z" -w /mnt "${SHELLCHECK_IMAGE}" '{}' + ; then
 		exit 1
 	fi
 }

--- a/hack/tool-images.sh
+++ b/hack/tool-images.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Pinned tool images used by hack/*.sh.
+# Container images use @sha256 digests (content-addressable integrity).
+# Renovate updates these for major/minor versions only (see renovate.json).
+
+export SHELLCHECK_IMAGE="docker.io/koalaman/shellcheck:v0.11.0@sha256:61862eba1fcf09a484ebcc6feea46f1782532571a34ed51fedf90dd25f925a8d"
+export HADOLINT_IMAGE="ghcr.io/hadolint/hadolint:v2.15.0@sha256:78cefa24d67e95cac4cdc388652068d0be545bd2926fcbec6f95c1a751d5da32"
+export RENOVATE_IMAGE="ghcr.io/renovatebot/renovate:44.4.5@sha256:43ab81533ca965a2a568995ba4d5c175b3637a5460192c9fe32fe66d8249c9b7"
+
+# Assert an image reference is digest-pinned (@sha256:...).
+# Usage: require_image_digest <image_ref> [name]
+require_image_digest()
+{
+	local image="$1"
+	local name="${2:-image}"
+
+	if [[ ! "${image}" =~ @sha256:[a-fA-F0-9]{64}$ ]]; then
+		echo "[$(date)] -- ERROR -- ${name} must be pinned with @sha256:<digest>: ${image}" >&2
+		return 1
+	fi
+	return 0
+}

--- a/renovate.json
+++ b/renovate.json
@@ -11,16 +11,76 @@
 	"rebaseLabel": "needs-rebase",
 	"rebaseWhen": "behind-base-branch",
 	"recreateWhen": "always",
+	"minimumReleaseAge": "7 days",
+	"customManagers": [
+		{
+			"customType": "regex",
+			"description": "Hack script tool images in hack/tool-images.sh (hadolint, shellcheck, renovate)",
+			"managerFilePatterns": ["/^hack\\/tool-images\\.sh$/"],
+			"matchStrings": [
+				"(?<depName>ghcr\\.io\\/hadolint\\/hadolint|docker\\.io\\/koalaman\\/shellcheck|ghcr\\.io\\/renovatebot\\/renovate):(?<currentValue>[^@\\s\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
+			],
+			"datasourceTemplate": "docker",
+			"versioningTemplate": "docker",
+			"autoReplaceStringTemplate": "{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
+		}
+	],
+	"packageRules": [
+		{
+			"description": "Hack script tool images: only major/minor (no patch/digest-only)",
+			"matchManagers": ["custom.regex"],
+			"matchPackageNames": [
+				"ghcr.io/hadolint/hadolint",
+				"docker.io/koalaman/shellcheck",
+				"ghcr.io/renovatebot/renovate"
+			],
+			"matchUpdateTypes": ["major", "minor"],
+			"minimumReleaseAge": "7 days",
+			"enabled": true,
+			"automerge": false
+		},
+		{
+			"description": "Disable patch/digest/pin updates for hack script tool images",
+			"matchManagers": ["custom.regex"],
+			"matchPackageNames": [
+				"ghcr.io/hadolint/hadolint",
+				"docker.io/koalaman/shellcheck",
+				"ghcr.io/renovatebot/renovate"
+			],
+			"matchUpdateTypes": ["patch", "digest", "pin", "pinDigest"],
+			"enabled": false
+		}
+	],
 	"tekton": {
 		"enabled": true,
 		"packageRules": [
 			{
-				"matchUpdateTypes": [
-					"minor",
-					"patch",
-					"pin",
-					"digest"
+				"description": "Disable all Tekton updates by default",
+				"matchDatasources": ["docker"],
+				"enabled": false
+			},
+			{
+				"description": "Konflux Tekton catalog image updates only (tag + digest); majors/minors require human review",
+				"matchDatasources": ["docker"],
+				"matchPackageNames": [
+					"/^quay\\.io\\/konflux-ci\\/tekton-catalog\\//",
+					"/^quay\\.io\\/redhat-appstudio-tekton-catalog\\//"
 				],
+				"matchUpdateTypes": ["major", "minor", "patch", "digest"],
+				"minimumReleaseAge": "7 days",
+				"enabled": true,
+				"automerge": false
+			},
+			{
+				"description": "Automerge only low-risk Tekton digest and patch image updates",
+				"matchDatasources": ["docker"],
+				"matchPackageNames": [
+					"/^quay\\.io\\/konflux-ci\\/tekton-catalog\\//",
+					"/^quay\\.io\\/redhat-appstudio-tekton-catalog\\//"
+				],
+				"matchUpdateTypes": ["digest", "patch"],
+				"minimumReleaseAge": "7 days",
+				"enabled": true,
 				"automerge": true,
 				"addLabels": ["approved", "lgtm"]
 			}
@@ -30,7 +90,16 @@
 		"enabled": true,
 		"packageRules": [
 			{
-				"matchFileNames": ["Containerfile.*"],
+				"description": "Disable all Containerfile image updates by default",
+				"matchDatasources": ["docker"],
+				"enabled": false
+			},
+			{
+				"description": "Only digest updates for images already pinned with @sha256 (nothing else)",
+				"matchCurrentValue": "/@sha256:[a-f0-9]+$/i",
+				"matchUpdateTypes": ["digest"],
+				"minimumReleaseAge": "3 days",
+				"enabled": true,
 				"automerge": true,
 				"addLabels": ["approved", "lgtm"]
 			}


### PR DESCRIPTION
## Summary
- Pin shellcheck, hadolint, and renovate image refs used by hack verify scripts to digests via `hack/tool-images.sh`
- Harden `renovate.json` the same way as main for Containerfiles, Tekton, and hack tool images
- Intentionally omits opm/skopeo pinning (FBC/catalog tooling exists only on `main`)

## Test plan
- [x] `make verify-shell-scripts`
- [x] `make verify-containerfiles`
- [x] `make validate-renovate-config`