### PR TITLE
[main] ESO-569, ESO-570, ESO-571: Pin hack tools and harden Renovate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,7 @@ IMAGE_VERSION ?= latest
 ## path to store the tools binary.
 TOOL_BIN_DIR = $(strip $(shell git rev-parse --show-toplevel --show-superproject-working-tree | tail -1))/bin/tools
 
-## Operator Package Manager tool to download.
-OPM_TOOL_VERSION ?= v1.48.0
-
-## URL to download Operator Package Manager tool.
-OPM_DOWNLOAD_URL = https://github.com/operator-framework/operator-registry/releases/download/$(OPM_TOOL_VERSION)/$(shell go env GOOS)-$(shell go env GOARCH)-opm
-
-## Operator Package Manager tool path.
+## Operator Package Manager tool path (version and sha256 pins live in hack/tool-images.sh).
 OPM_TOOL_PATH ?= $(TOOL_BIN_DIR)/opm
 
 ## Operator bundle image to use for generating catalog.
@@ -90,19 +84,10 @@ verify-containerfiles:
 .PHONY: verify
 verify: verify-shell-scripts verify-containerfiles validate-renovate-config
 
-## get opm(operator package manager) tool.
+## get opm(operator package manager) tool (pinned version + sha256 in hack/tool-images.sh).
 .PHONY: get-opm
 get-opm:
-	$(call get-bin,$(OPM_TOOL_PATH),$(TOOL_BIN_DIR),$(OPM_DOWNLOAD_URL))
-
-define get-bin
-@[ -f "$(1)" ] || { \
-	[ ! -d "$(2)" ] && mkdir -p "$(2)" || true ;\
-	echo "Downloading $(3)" ;\
-	curl -fL $(3) -o "$(1)" ;\
-	chmod +x "$(1)" ;\
-}
-endef
+	./hack/get-opm.sh $(TOOL_BIN_DIR)
 
 ## clean up temp dirs, images.
 .PHONY: clean

--- a/hack/containerfile-linter.sh
+++ b/hack/containerfile-linter.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091 # sourced file path is runtime-resolved
+source "$(dirname "${BASH_SOURCE[0]}")/tool-images.sh"
+
 declare -a CONTAINERFILES
 declare -a EXTERNAL_SECRETS_OPERATOR_CONTAINERFILES
 
-
 linter()
 {
+	require_image_digest "${HADOLINT_IMAGE}" "HADOLINT_IMAGE"
 	containerfiles=("$@")
 	for containerfile in "${containerfiles[@]}"; do
 		if [[ ! -f "${containerfile}" ]]; then
@@ -13,7 +16,7 @@ linter()
 			exit 1
 		fi
 		echo "[$(date)] -- INFO  -- running linter on ${containerfile}"
-		if ! podman run --rm -i -e "HADOLINT_FAILURE_THRESHOLD=error" ghcr.io/hadolint/hadolint < "${containerfile}" ; then
+		if ! podman run --rm -i -e "HADOLINT_FAILURE_THRESHOLD=error" "${HADOLINT_IMAGE}" < "${containerfile}" ; then
 			exit 1
 		fi
 	done

--- a/hack/get-opm.sh
+++ b/hack/get-opm.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Download the pinned opm binary into TOOL_BIN_DIR and verify its SHA-256 checksum.
+
+set -euo pipefail
+
+# shellcheck disable=SC1091 # sourced file path is runtime-resolved
+source "$(dirname "${BASH_SOURCE[0]}")/tool-images.sh"
+
+TOOL_BIN_DIR="${1:?TOOL_BIN_DIR is required}"
+OPM_TOOL_PATH="${TOOL_BIN_DIR}/opm"
+
+os="$(go env GOOS)"
+arch="$(go env GOARCH)"
+checksum_var="OPM_SHA256_${os}_${arch}"
+
+if [[ -z "${!checksum_var:-}" ]]; then
+	echo "[$(date)] -- ERROR -- no pinned sha256 for opm ${os}/${arch} (OPM_TOOL_VERSION=${OPM_TOOL_VERSION})" >&2
+	exit 1
+fi
+expected_sha256="${!checksum_var}"
+download_url="${OPM_DOWNLOAD_BASE_URL}/${os}-${arch}-opm"
+
+mkdir -p "${TOOL_BIN_DIR}"
+
+if [[ -f "${OPM_TOOL_PATH}" ]]; then
+	if verify_sha256 "${OPM_TOOL_PATH}" "${expected_sha256}"; then
+		exit 0
+	fi
+	echo "[$(date)] -- INFO  -- existing opm failed checksum check; re-downloading"
+	rm -f "${OPM_TOOL_PATH}"
+fi
+
+echo "[$(date)] -- INFO  -- downloading opm ${OPM_TOOL_VERSION} (${os}/${arch})"
+echo "[$(date)] -- INFO  --   ${download_url}"
+curl -fL "${download_url}" -o "${OPM_TOOL_PATH}"
+chmod +x "${OPM_TOOL_PATH}"
+
+if ! verify_sha256 "${OPM_TOOL_PATH}" "${expected_sha256}"; then
+	rm -f "${OPM_TOOL_PATH}"
+	exit 1
+fi

--- a/hack/renovate-config-validator.sh
+++ b/hack/renovate-config-validator.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091 # sourced file path is runtime-resolved
+source "$(dirname "${BASH_SOURCE[0]}")/tool-images.sh"
+
 validate_config()
 {
-	if ! podman run -e "LOG_LEVEL=debug" --rm -v "./renovate.json:/tmp/validate/renovate.json:Z" -w /tmp/validate ghcr.io/renovatebot/renovate \
+	require_image_digest "${RENOVATE_IMAGE}" "RENOVATE_IMAGE"
+	if ! podman run -e "LOG_LEVEL=debug" --rm -v "./renovate.json:/tmp/validate/renovate.json:Z" -w /tmp/validate \
+		"${RENOVATE_IMAGE}" \
 		renovate-config-validator --strict /tmp/validate/renovate.json; then
 		exit 1
 	fi

--- a/hack/shell-scripts-linter.sh
+++ b/hack/shell-scripts-linter.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091 # sourced file path is runtime-resolved
+source "$(dirname "${BASH_SOURCE[0]}")/tool-images.sh"
+
 verify_script()
 {
+  require_image_digest "${SHELLCHECK_IMAGE}" "SHELLCHECK_IMAGE"
   if ! find . -type f -name '*.sh' '!' -path './external-secrets/*' '!' -path './external-secrets-operator/*' \
 		-printf "[$(date)] -- INFO  -- checking file %p\n" \
-		-exec podman run --rm -v "$PWD:/mnt:Z" -w /mnt docker.io/koalaman/shellcheck:stable '{}' + ; then
+		-exec podman run --rm -v "$PWD:/mnt:Z" -w /mnt "${SHELLCHECK_IMAGE}" '{}' + ; then
 		exit 1
 	fi
 }

--- a/hack/tool-images.sh
+++ b/hack/tool-images.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Pinned tool images and binaries used by hack/*.sh and Makefile.
+# Container images use @sha256 digests (content-addressable integrity).
+# OPM uses version + per-arch SHA256 checksums verified with sha256sum.
+# Renovate updates container images for major/minor versions only (see renovate.json).
+
+export SHELLCHECK_IMAGE="docker.io/koalaman/shellcheck:v0.11.0@sha256:61862eba1fcf09a484ebcc6feea46f1782532571a34ed51fedf90dd25f925a8d"
+export HADOLINT_IMAGE="ghcr.io/hadolint/hadolint:v2.15.0@sha256:78cefa24d67e95cac4cdc388652068d0be545bd2926fcbec6f95c1a751d5da32"
+export RENOVATE_IMAGE="ghcr.io/renovatebot/renovate:44.4.5@sha256:43ab81533ca965a2a568995ba4d5c175b3637a5460192c9fe32fe66d8249c9b7"
+export SKOPEO_IMAGE="registry.access.redhat.com/ubi9/skopeo:9.8-1785444819@sha256:ce2108ada76f38efec293b9a41924122fd000d02af0324994378c4766f301650"
+
+# Operator Package Manager (opm) — checksums from:
+# https://github.com/operator-framework/operator-registry/releases/download/${OPM_TOOL_VERSION}/checksums.txt
+export OPM_TOOL_VERSION="v1.48.0"
+export OPM_DOWNLOAD_BASE_URL="https://github.com/operator-framework/operator-registry/releases/download/${OPM_TOOL_VERSION}"
+
+export OPM_SHA256_darwin_amd64="b14a40541eed5bfef9648e9f37c8cb18d801deb385624c0ac93df56e9f9df45a"
+export OPM_SHA256_darwin_arm64="51633a9cf9c1b36b56a4bd0da3d1c31acce0afb1d27fa619b85faa0ecc7b9ba5"
+export OPM_SHA256_linux_amd64="0a301826baff730489162caff13e04f7dc16c1a79072cbcbdfc5379d95caef40"
+export OPM_SHA256_linux_arm64="4c5ee23f33492c0cd4bdc2cc605728814cc38f889c758f5e7d1ac4e217f80f0c"
+export OPM_SHA256_linux_ppc64le="352211a27acded101f8b769c02cd75cb737306a9090becb0649d899cb4bbf228"
+export OPM_SHA256_linux_s390x="e029cfd7a76d833aa9e8f6340979b61b9829448fed878bee1efa06dae856732b"
+
+# Verify file contents match an expected SHA-256 hex digest.
+# Usage: verify_sha256 <file> <expected_hex>
+verify_sha256()
+{
+	local file="$1"
+	local expected="$2"
+	local actual
+
+	if [[ ! -f "${file}" ]]; then
+		echo "[$(date)] -- ERROR -- cannot verify sha256: \"${file}\" does not exist" >&2
+		return 1
+	fi
+	if [[ ! "${expected}" =~ ^[a-fA-F0-9]{64}$ ]]; then
+		echo "[$(date)] -- ERROR -- invalid expected sha256 for \"${file}\": ${expected}" >&2
+		return 1
+	fi
+
+	actual="$(sha256sum "${file}" | awk '{print $1}')"
+	if [[ "${actual}" != "${expected}" ]]; then
+		echo "[$(date)] -- ERROR -- sha256 mismatch for \"${file}\"" >&2
+		echo "[$(date)] -- ERROR --   expected: ${expected}" >&2
+		echo "[$(date)] -- ERROR --   actual:   ${actual}" >&2
+		return 1
+	fi
+	echo "[$(date)] -- INFO  -- sha256 OK for \"${file}\""
+	return 0
+}
+
+# Assert an image reference is digest-pinned (@sha256:...).
+# Usage: require_image_digest <image_ref> [name]
+require_image_digest()
+{
+	local image="$1"
+	local name="${2:-image}"
+
+	if [[ ! "${image}" =~ @sha256:[a-fA-F0-9]{64}$ ]]; then
+		echo "[$(date)] -- ERROR -- ${name} must be pinned with @sha256:<digest>: ${image}" >&2
+		return 1
+	fi
+	return 0
+}

--- a/hack/update_catalog.sh
+++ b/hack/update_catalog.sh
@@ -27,6 +27,9 @@ declare CATALOG_DIR
 declare BUNDLE_FILE_NAME
 declare REPLICATE_BUNDLE_FILE_IN_CATALOGS
 
+# shellcheck disable=SC1091 # sourced file path is runtime-resolved
+source "$(dirname "${BASH_SOURCE[0]}")/tool-images.sh"
+
 EXTERNAL_SECRETS_OPERATOR_CATALOG_NAME="openshift-external-secrets-operator"
 GREEN_COLOR_TEXT='\033[0;32m'
 RED_COLOR_TEXT='\033[0;31m'
@@ -58,8 +61,10 @@ verify_bundle_image()
 	fi
 
 	log_info "inspecting ${OPERATOR_BUNDLE_IMAGE} bundle image"
+	require_image_digest "${SKOPEO_IMAGE}" "SKOPEO_IMAGE"
 	media_type="$(podman run -e REGISTRY_AUTH_FILE="/tmp/auth.json" --rm -v "${auth_file}:/tmp/auth.json:Z" \
-		quay.io/skopeo/stable:latest inspect --raw docker://"${OPERATOR_BUNDLE_IMAGE}" | jq -r .mediaType)"
+		"${SKOPEO_IMAGE}" \
+		skopeo inspect --raw docker://"${OPERATOR_BUNDLE_IMAGE}" | jq -r .mediaType)"
 
 	case $media_type in
 		application/vnd.oci.image.manifest.v1+json|application/vnd.docker.distribution.manifest.v2+json)

--- a/renovate.json
+++ b/renovate.json
@@ -11,16 +11,83 @@
 	"rebaseLabel": "needs-rebase",
 	"rebaseWhen": "behind-base-branch",
 	"recreateWhen": "always",
+	"minimumReleaseAge": "7 days",
+	"customManagers": [
+		{
+			"customType": "regex",
+			"description": "Hack script tool images in hack/tool-images.sh (skopeo, hadolint, shellcheck, renovate)",
+			"managerFilePatterns": ["/^hack\\/tool-images\\.sh$/"],
+			"matchStrings": [
+				"(?<depName>registry\\.access\\.redhat\\.com\\/ubi9\\/skopeo|ghcr\\.io\\/hadolint\\/hadolint|docker\\.io\\/koalaman\\/shellcheck|ghcr\\.io\\/renovatebot\\/renovate):(?<currentValue>[^@\\s\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
+			],
+			"datasourceTemplate": "docker",
+			"versioningTemplate": "docker",
+			"autoReplaceStringTemplate": "{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
+		}
+	],
+	"packageRules": [
+		{
+			"description": "Use Red Hat versioning for ubi9/skopeo tags (e.g. 9.8-1785444819)",
+			"matchPackageNames": ["registry.access.redhat.com/ubi9/skopeo"],
+			"versioning": "redhat"
+		},
+		{
+			"description": "Hack script tool images: only major/minor (no patch/digest-only)",
+			"matchManagers": ["custom.regex"],
+			"matchPackageNames": [
+				"registry.access.redhat.com/ubi9/skopeo",
+				"ghcr.io/hadolint/hadolint",
+				"docker.io/koalaman/shellcheck",
+				"ghcr.io/renovatebot/renovate"
+			],
+			"matchUpdateTypes": ["major", "minor"],
+			"minimumReleaseAge": "7 days",
+			"enabled": true,
+			"automerge": false
+		},
+		{
+			"description": "Disable patch/digest/pin updates for hack script tool images",
+			"matchManagers": ["custom.regex"],
+			"matchPackageNames": [
+				"registry.access.redhat.com/ubi9/skopeo",
+				"ghcr.io/hadolint/hadolint",
+				"docker.io/koalaman/shellcheck",
+				"ghcr.io/renovatebot/renovate"
+			],
+			"matchUpdateTypes": ["patch", "digest", "pin", "pinDigest"],
+			"enabled": false
+		}
+	],
 	"tekton": {
 		"enabled": true,
 		"packageRules": [
 			{
-				"matchUpdateTypes": [
-					"minor",
-					"patch",
-					"pin",
-					"digest"
+				"description": "Disable all Tekton updates by default",
+				"matchDatasources": ["docker"],
+				"enabled": false
+			},
+			{
+				"description": "Konflux Tekton catalog image updates only (tag + digest); majors/minors require human review",
+				"matchDatasources": ["docker"],
+				"matchPackageNames": [
+					"/^quay\\.io\\/konflux-ci\\/tekton-catalog\\//",
+					"/^quay\\.io\\/redhat-appstudio-tekton-catalog\\//"
 				],
+				"matchUpdateTypes": ["major", "minor", "patch", "digest"],
+				"minimumReleaseAge": "7 days",
+				"enabled": true,
+				"automerge": false
+			},
+			{
+				"description": "Automerge only low-risk Tekton digest and patch image updates",
+				"matchDatasources": ["docker"],
+				"matchPackageNames": [
+					"/^quay\\.io\\/konflux-ci\\/tekton-catalog\\//",
+					"/^quay\\.io\\/redhat-appstudio-tekton-catalog\\//"
+				],
+				"matchUpdateTypes": ["digest", "patch"],
+				"minimumReleaseAge": "7 days",
+				"enabled": true,
 				"automerge": true,
 				"addLabels": ["approved", "lgtm"]
 			}
@@ -30,7 +97,16 @@
 		"enabled": true,
 		"packageRules": [
 			{
-				"matchFileNames": ["Containerfile.*"],
+				"description": "Disable all Containerfile image updates by default",
+				"matchDatasources": ["docker"],
+				"enabled": false
+			},
+			{
+				"description": "Only digest updates for images already pinned with @sha256 (nothing else)",
+				"matchCurrentValue": "/@sha256:[a-f0-9]+$/i",
+				"matchUpdateTypes": ["digest"],
+				"minimumReleaseAge": "3 days",
+				"enabled": true,
 				"automerge": true,
 				"addLabels": ["approved", "lgtm"]
 			}


### PR DESCRIPTION
## Summary
- Pin shellcheck, hadolint, renovate, and skopeo image refs used by hack scripts to digests via `hack/tool-images.sh`
- Pin `opm` version with per-arch SHA-256 verification in `hack/get-opm.sh` (used for FBC/catalog updates)
- Harden `renovate.json`: default-deny Containerfile/Tekton docker updates, digest-only for already-pinned Containerfiles, Konflux Tekton catalog rules, and major/minor-only updates for hack tool images

## Test plan
- [x] `make verify-shell-scripts`
- [x] `make verify-containerfiles`
- [x] `make validate-renovate-config`
- [x] `make get-opm` downloads and reports `sha256 OK`; rerunning is a no-op when the pin matches