### PR TITLE
[release-1.1] ESO-527: Updates the operator bundle with the latest staged images

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,10 +4,10 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # external-secrets operand image digest.
-EXTERNAL_SECRETS_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:ac9f75e7a0bccdb770f2b09a0ff044b9fe8692c4da058577cdaad54caa702c16
+EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:9d2fde3c6e71472f781020c758e33036c1c87117cc530db72602bc6dc5b92174
 
 # bitwarden-sdk-server operand image digest.
-BITWARDEN_SDK_SERVER_IMAGE=registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:ff474c98280b839d3744c2590a70c7b1eac12d0e1fef373a618a4c9fb4221647
+BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:1c7e9ddf3c6bf763ca04aeb1896ebb6ce8e70baed961c72bf81a26d33efa6e7d
 
 # external-secrets-operator image digest.
-EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:ffa7e19dea031e510f656145416b8cebce558d34c9a7e1fecb506f0d80b3fc3c
+EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8


### PR DESCRIPTION
The PR has the changes for the updating the latest v1.1.1 staged images in the bundle.

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/c9b3e787e87c8cc23ed1e6755a6e277685164fae",
                    "version": "v1.1.1"
```

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:1c7e9ddf3c6bf763ca04aeb1896ebb6ce8e70baed961c72bf81a26d33efa6e7d | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/c9b3e787e87c8cc23ed1e6755a6e277685164fae",
                    "version": "v0.5.2"
```

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:9d2fde3c6e71472f781020c758e33036c1c87117cc530db72602bc6dc5b92174 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/c9b3e787e87c8cc23ed1e6755a6e277685164fae",
                    "version": "v0.20.4-1"
```