### PR TITLE
ESO-527: Updates the latest staged bundle image in 4.18 - 4.22 OCP catalogs

### DIFF
--- a/catalogs/v4.18/catalog/openshift-external-secrets-operator/bundle-v1.1.1.yaml
+++ b/catalogs/v4.18/catalog/openshift-external-secrets-operator/bundle-v1.1.1.yaml
@@ -1,0 +1,605 @@
+---
+image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:024c26fc77e759f23408736c1d726064916e4588dcbbf90d76c7fc5c0b5ca0d1
+name: openshift-external-secrets-operator.v1.1.1
+package: openshift-external-secrets-operator
+properties:
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterExternalSecret
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterExternalSecret
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterPushSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterSecretStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterSecretStore
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ExternalSecret
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ExternalSecret
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: PushSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: SecretStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: SecretStore
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ACRAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: CloudsmithAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ClusterGenerator
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ECRAuthorizationToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GCRAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GeneratorState
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GithubAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Grafana
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: MFA
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Password
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: QuayAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: SSHKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: STSSessionToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: UUID
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: VaultDynamicSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Webhook
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ExternalSecretsConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ExternalSecretsManager
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-external-secrets-operator
+    version: 1.1.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ClusterExternalSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "secret-cluster"
+            },
+            "spec": {
+              "externalSecretSpec": {
+                "data": [
+                  {
+                    "remoteRef": {
+                      "key": "gcp-secret"
+                    },
+                    "secretKey": "key"
+                  }
+                ],
+                "refreshInterval": "1h",
+                "secretStoreRef": {
+                  "kind": "ClusterSecretStore",
+                  "name": "gcp-cluster-secretstore"
+                },
+                "target": {
+                  "creationPolicy": "Owner",
+                  "name": "gcp-secret-k8s"
+                }
+              },
+              "namespaceSelector": {
+                "matchLabels": {
+                  "app.kubernetes.io/managed-by": "external-secrets-operator"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ClusterSecretStore",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "gcp-cluster-secretstore"
+            },
+            "spec": {
+              "provider": {
+                "gcpsm": {
+                  "auth": {
+                    "secretRef": {
+                      "secretAccessKeySecretRef": {
+                        "key": "secret-access-key.json",
+                        "name": "gcp-creds",
+                        "namespace": "external-secrets"
+                      }
+                    }
+                  },
+                  "projectID": "openshift-sample-project"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ExternalSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "gcp-secret",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "data": [
+                {
+                  "remoteRef": {
+                    "key": "gcp-secret",
+                    "property": "Key"
+                  },
+                  "secretKey": "Key"
+                }
+              ],
+              "refreshInterval": "1h",
+              "secretStoreRef": {
+                "kind": "SecretStore",
+                "name": "secretstore"
+              },
+              "target": {
+                "creationPolicy": "Owner",
+                "name": "k8s-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "SecretStore",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/disable-maintenance-checks": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "secretstore",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "provider": {
+                "gcpsm": {
+                  "auth": {
+                    "secretRef": {
+                      "secretAccessKeySecretRef": {
+                        "key": "secret-access-key.json",
+                        "name": "gcp-creds"
+                      }
+                    }
+                  },
+                  "projectID": "openshift-sample-project"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1alpha1",
+            "kind": "PushSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "pushsecret-sample",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "config": {
+                "gcp": {
+                  "projectID": "openshift-sample-project",
+                  "secret": {
+                    "name": "test",
+                    "replicationPolicy": "automatic",
+                    "version": "latest"
+                  }
+                }
+              },
+              "secretStoreRefs": [
+                {
+                  "kind": "ClusterSecretStore",
+                  "name": "gcp-cluster-secretstore"
+                }
+              ],
+              "selector": {
+                "secret": {
+                  "name": "gcp-secret-k8s"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "generators.external-secrets.io/v1alpha1",
+            "kind": "Password",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "password-sample",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "excludeLowercase": false,
+              "excludeNumbers": false,
+              "excludeUppercase": false,
+              "includeSymbols": true,
+              "length": 20
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ExternalSecretsConfig",
+            "metadata": {
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "cluster"
+            },
+            "spec": {}
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ExternalSecretsManager",
+            "metadata": {
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "cluster"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8
+      createdAt: 2026-08-11T11:24:58
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.1.0 <1.1.1'
+      operator.openshift.io/uninstall-message: The External Secrets Operator for Red
+        Hat OpenShift will be removed from external-secrets-operator namespace. If
+        your Operator configured any off-cluster resources, these will continue to
+        run and require manual cleanup. All operands created by the operator will
+        need to be manually cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/external_secrets_operator/external-secrets-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: external-secrets-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.39.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/openshift/external-secrets-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: |-
+          ACRAccessToken returns an Azure Container Registry token that can be used for pushing/pulling images.
+          Note: by default it will return an ACR Refresh Token with full access (depending on the identity).
+          This can be scoped down to the repository level using .spec.scope. In case scope is defined it will return an ACR Access Token.
+
+          See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md
+        displayName: ACRAccessToken
+        kind: ACRAccessToken
+        name: acraccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: CloudsmithAccessToken generates Cloudsmith access token using
+          OIDC authentication
+        displayName: CloudsmithAccessToken
+        kind: CloudsmithAccessToken
+        name: cloudsmithaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: ClusterExternalSecret is the Schema for the clusterexternalsecrets
+          API.
+        displayName: ClusterExternalSecret
+        kind: ClusterExternalSecret
+        name: clusterexternalsecrets.external-secrets.io
+        version: v1
+      - description: ClusterGenerator represents a cluster-wide generator which can
+          be referenced as part of `generatorRef` fields.
+        displayName: ClusterGenerator
+        kind: ClusterGenerator
+        name: clustergenerators.generators.external-secrets.io
+        version: v1alpha1
+      - description: ClusterPushSecret is the Schema for the clusterpushsecrets API.
+        displayName: ClusterPushSecret
+        kind: ClusterPushSecret
+        name: clusterpushsecrets.external-secrets.io
+        version: v1alpha1
+      - description: ClusterSecretStore represents a secure external location for
+          storing secrets, which can be referenced as part of `storeRef` fields.
+        displayName: ClusterSecretStore
+        kind: ClusterSecretStore
+        name: clustersecretstores.external-secrets.io
+        version: v1
+      - description: |-
+          ECRAuthorizationToken uses the GetAuthorizationToken API to retrieve an authorization token. The authorization
+          token is valid for 12 hours. The authorizationToken returned is a base64 encoded string that can be decoded and
+          used in a Docker login command to authenticate to a registry. For more information, see Registry authentication
+          (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth)
+          in the Amazon Elastic Container Registry User Guide.
+        displayName: ECRAuthorizationToken
+        kind: ECRAuthorizationToken
+        name: ecrauthorizationtokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: ExternalSecret is the Schema for the external-secrets API.
+        displayName: ExternalSecret
+        kind: ExternalSecret
+        name: externalsecrets.external-secrets.io
+        version: v1
+      - description: |-
+          ExternalSecretsConfig describes configuration and information about the managed external-secrets deployment.
+          The name must be `cluster` as ExternalSecretsConfig is a singleton, allowing only one instance per cluster.
+
+          When an ExternalSecretsConfig is created, the controller installs the external-secrets and keeps it in the desired state.
+        displayName: ExternalSecretsConfig
+        kind: ExternalSecretsConfig
+        name: externalsecretsconfigs.operator.openshift.io
+        version: v1alpha1
+      - description: |-
+          ExternalSecretsManager describes configuration and information about the deployments managed by
+          the operator. The name must be `cluster` to make ExternalSecretsManager a singleton that is, to
+          allow only one instance of ExternalSecretsManager per cluster.
+
+          ExternalSecretsManager is mainly for configuring the global options and enabling the features, which
+          serves as a common/centralized config for managing multiple controllers of the operator. The object
+          will be created during the operator installation.
+        displayName: ExternalSecretsManager
+        kind: ExternalSecretsManager
+        name: externalsecretsmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: GCRAccessToken generates a GCP access token that can be used
+          to authenticate with GCR.
+        displayName: GCRAccessToken
+        kind: GCRAccessToken
+        name: gcraccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: GeneratorState is the Schema for the generatorstates API.
+        displayName: GeneratorState
+        kind: GeneratorState
+        name: generatorstates.generators.external-secrets.io
+        version: v1alpha1
+      - description: GithubAccessToken generates a ghs_ access token
+        displayName: GithubAccessToken
+        kind: GithubAccessToken
+        name: githubaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: Grafana is the Schema for the grafanas API.
+        displayName: Grafana
+        kind: Grafana
+        name: grafanas.generators.external-secrets.io
+        version: v1alpha1
+      - description: MFA generates a new TOTP token that is compliant with RFC 6238.
+        displayName: MFA
+        kind: MFA
+        name: mfas.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          Password generates a random password based on the configuration parameters in spec. You can specify the length,
+          character set and other attributes.
+        displayName: Password
+        kind: Password
+        name: passwords.generators.external-secrets.io
+        version: v1alpha1
+      - description: PushSecret is the Schema for the pushsecrets API.
+        displayName: PushSecret
+        kind: PushSecret
+        name: pushsecrets.external-secrets.io
+        version: v1alpha1
+      - description: QuayAccessToken generates a Quay OAuth token for pulling/pushing
+          images.
+        displayName: QuayAccessToken
+        kind: QuayAccessToken
+        name: quayaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: SecretStore represents a secure external location for storing
+          secrets, which can be referenced as part of `storeRef` fields.
+        displayName: SecretStore
+        kind: SecretStore
+        name: secretstores.external-secrets.io
+        version: v1
+      - description: SSHKey generates SSH key pairs.
+        displayName: SSHKey
+        kind: SSHKey
+        name: sshkeys.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          STSSessionToken uses the GetSessionToken API to retrieve an authorization token. The authorization token is
+          valid for 12 hours. The authorizationToken returned is a base64 encoded string that can be decoded.
+          For more information, see GetSessionToken (https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html).
+        displayName: STSSessionToken
+        kind: STSSessionToken
+        name: stssessiontokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: UUID generates a version 1 UUID (for example, 6ba7b810-9dad-11d1-80b4-00c04fd430c8).
+        displayName: UUID
+        kind: UUID
+        name: uuids.generators.external-secrets.io
+        version: v1alpha1
+      - description: VaultDynamicSecret is the Schema for the vaultdynamicsecrets
+          API.
+        displayName: VaultDynamicSecret
+        kind: VaultDynamicSecret
+        name: vaultdynamicsecrets.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          Webhook connects to a third party API server to handle the secrets generation configuration parameters in spec. You
+          can specify the server, the token, and additional body parameters. See documentation for the full API specification
+          for requests and responses.
+        displayName: Webhook
+        kind: Webhook
+        name: webhooks.generators.external-secrets.io
+        version: v1alpha1
+    description: External Secrets Operator for Red Hat OpenShift deploys and manages
+      `external-secrets` application in OpenShift clusters. `external-secrets` provides
+      an uniform interface to fetch secrets stored in external providers like  AWS
+      Secrets Manager, HashiCorp Vault, Google Secrets Manager, Azure Key Vault, IBM
+      Cloud Secrets Manager to name a few, stores them as secrets in OpenShift. It
+      provides APIs to define authentication and the details of the secret to fetch.
+    displayName: External Secrets Operator for Red Hat OpenShift
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - secrets
+    - external-secrets
+    - external-secrets-operator
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/security_and_compliance/external-secrets-operator-for-red-hat-openshift
+    - name: External Secrets Operator
+      url: https://github.com/openshift/external-secrets-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat, Inc.
+relatedImages:
+- image: registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:1c7e9ddf3c6bf763ca04aeb1896ebb6ce8e70baed961c72bf81a26d33efa6e7d
+  name: bitwarden-sdk-server
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:024c26fc77e759f23408736c1d726064916e4588dcbbf90d76c7fc5c0b5ca0d1
+  name: ""
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8
+  name: ""
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:9d2fde3c6e71472f781020c758e33036c1c87117cc530db72602bc6dc5b92174
+  name: external-secrets
+schema: olm.bundle

--- a/catalogs/v4.18/catalog/openshift-external-secrets-operator/channel.yaml
+++ b/catalogs/v4.18/catalog/openshift-external-secrets-operator/channel.yaml
@@ -2,6 +2,9 @@
 entries:
 - name: openshift-external-secrets-operator.v1.1.0
   skipRange: '<1.1.0'
+- name: openshift-external-secrets-operator.v1.1.1
+  replaces: openshift-external-secrets-operator.v1.1.0
+  skipRange: '>=1.1.0 <1.1.1'
 name: stable-v1
 package: openshift-external-secrets-operator
 schema: olm.channel
@@ -9,6 +12,9 @@ schema: olm.channel
 entries:
 - name: openshift-external-secrets-operator.v1.1.0
   skipRange: '<1.1.0'
+- name: openshift-external-secrets-operator.v1.1.1
+  replaces: openshift-external-secrets-operator.v1.1.0
+  skipRange: '>=1.1.0 <1.1.1'
 name: stable-v1.1
 package: openshift-external-secrets-operator
 schema: olm.channel

--- a/catalogs/v4.19/catalog/openshift-external-secrets-operator/bundle-v1.1.1.yaml
+++ b/catalogs/v4.19/catalog/openshift-external-secrets-operator/bundle-v1.1.1.yaml
@@ -1,0 +1,605 @@
+---
+image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:024c26fc77e759f23408736c1d726064916e4588dcbbf90d76c7fc5c0b5ca0d1
+name: openshift-external-secrets-operator.v1.1.1
+package: openshift-external-secrets-operator
+properties:
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterExternalSecret
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterExternalSecret
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterPushSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterSecretStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterSecretStore
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ExternalSecret
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ExternalSecret
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: PushSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: SecretStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: SecretStore
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ACRAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: CloudsmithAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ClusterGenerator
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ECRAuthorizationToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GCRAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GeneratorState
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GithubAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Grafana
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: MFA
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Password
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: QuayAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: SSHKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: STSSessionToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: UUID
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: VaultDynamicSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Webhook
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ExternalSecretsConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ExternalSecretsManager
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-external-secrets-operator
+    version: 1.1.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ClusterExternalSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "secret-cluster"
+            },
+            "spec": {
+              "externalSecretSpec": {
+                "data": [
+                  {
+                    "remoteRef": {
+                      "key": "gcp-secret"
+                    },
+                    "secretKey": "key"
+                  }
+                ],
+                "refreshInterval": "1h",
+                "secretStoreRef": {
+                  "kind": "ClusterSecretStore",
+                  "name": "gcp-cluster-secretstore"
+                },
+                "target": {
+                  "creationPolicy": "Owner",
+                  "name": "gcp-secret-k8s"
+                }
+              },
+              "namespaceSelector": {
+                "matchLabels": {
+                  "app.kubernetes.io/managed-by": "external-secrets-operator"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ClusterSecretStore",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "gcp-cluster-secretstore"
+            },
+            "spec": {
+              "provider": {
+                "gcpsm": {
+                  "auth": {
+                    "secretRef": {
+                      "secretAccessKeySecretRef": {
+                        "key": "secret-access-key.json",
+                        "name": "gcp-creds",
+                        "namespace": "external-secrets"
+                      }
+                    }
+                  },
+                  "projectID": "openshift-sample-project"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ExternalSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "gcp-secret",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "data": [
+                {
+                  "remoteRef": {
+                    "key": "gcp-secret",
+                    "property": "Key"
+                  },
+                  "secretKey": "Key"
+                }
+              ],
+              "refreshInterval": "1h",
+              "secretStoreRef": {
+                "kind": "SecretStore",
+                "name": "secretstore"
+              },
+              "target": {
+                "creationPolicy": "Owner",
+                "name": "k8s-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "SecretStore",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/disable-maintenance-checks": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "secretstore",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "provider": {
+                "gcpsm": {
+                  "auth": {
+                    "secretRef": {
+                      "secretAccessKeySecretRef": {
+                        "key": "secret-access-key.json",
+                        "name": "gcp-creds"
+                      }
+                    }
+                  },
+                  "projectID": "openshift-sample-project"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1alpha1",
+            "kind": "PushSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "pushsecret-sample",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "config": {
+                "gcp": {
+                  "projectID": "openshift-sample-project",
+                  "secret": {
+                    "name": "test",
+                    "replicationPolicy": "automatic",
+                    "version": "latest"
+                  }
+                }
+              },
+              "secretStoreRefs": [
+                {
+                  "kind": "ClusterSecretStore",
+                  "name": "gcp-cluster-secretstore"
+                }
+              ],
+              "selector": {
+                "secret": {
+                  "name": "gcp-secret-k8s"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "generators.external-secrets.io/v1alpha1",
+            "kind": "Password",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "password-sample",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "excludeLowercase": false,
+              "excludeNumbers": false,
+              "excludeUppercase": false,
+              "includeSymbols": true,
+              "length": 20
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ExternalSecretsConfig",
+            "metadata": {
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "cluster"
+            },
+            "spec": {}
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ExternalSecretsManager",
+            "metadata": {
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "cluster"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8
+      createdAt: 2026-08-11T11:24:58
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.1.0 <1.1.1'
+      operator.openshift.io/uninstall-message: The External Secrets Operator for Red
+        Hat OpenShift will be removed from external-secrets-operator namespace. If
+        your Operator configured any off-cluster resources, these will continue to
+        run and require manual cleanup. All operands created by the operator will
+        need to be manually cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/external_secrets_operator/external-secrets-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: external-secrets-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.39.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/openshift/external-secrets-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: |-
+          ACRAccessToken returns an Azure Container Registry token that can be used for pushing/pulling images.
+          Note: by default it will return an ACR Refresh Token with full access (depending on the identity).
+          This can be scoped down to the repository level using .spec.scope. In case scope is defined it will return an ACR Access Token.
+
+          See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md
+        displayName: ACRAccessToken
+        kind: ACRAccessToken
+        name: acraccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: CloudsmithAccessToken generates Cloudsmith access token using
+          OIDC authentication
+        displayName: CloudsmithAccessToken
+        kind: CloudsmithAccessToken
+        name: cloudsmithaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: ClusterExternalSecret is the Schema for the clusterexternalsecrets
+          API.
+        displayName: ClusterExternalSecret
+        kind: ClusterExternalSecret
+        name: clusterexternalsecrets.external-secrets.io
+        version: v1
+      - description: ClusterGenerator represents a cluster-wide generator which can
+          be referenced as part of `generatorRef` fields.
+        displayName: ClusterGenerator
+        kind: ClusterGenerator
+        name: clustergenerators.generators.external-secrets.io
+        version: v1alpha1
+      - description: ClusterPushSecret is the Schema for the clusterpushsecrets API.
+        displayName: ClusterPushSecret
+        kind: ClusterPushSecret
+        name: clusterpushsecrets.external-secrets.io
+        version: v1alpha1
+      - description: ClusterSecretStore represents a secure external location for
+          storing secrets, which can be referenced as part of `storeRef` fields.
+        displayName: ClusterSecretStore
+        kind: ClusterSecretStore
+        name: clustersecretstores.external-secrets.io
+        version: v1
+      - description: |-
+          ECRAuthorizationToken uses the GetAuthorizationToken API to retrieve an authorization token. The authorization
+          token is valid for 12 hours. The authorizationToken returned is a base64 encoded string that can be decoded and
+          used in a Docker login command to authenticate to a registry. For more information, see Registry authentication
+          (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth)
+          in the Amazon Elastic Container Registry User Guide.
+        displayName: ECRAuthorizationToken
+        kind: ECRAuthorizationToken
+        name: ecrauthorizationtokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: ExternalSecret is the Schema for the external-secrets API.
+        displayName: ExternalSecret
+        kind: ExternalSecret
+        name: externalsecrets.external-secrets.io
+        version: v1
+      - description: |-
+          ExternalSecretsConfig describes configuration and information about the managed external-secrets deployment.
+          The name must be `cluster` as ExternalSecretsConfig is a singleton, allowing only one instance per cluster.
+
+          When an ExternalSecretsConfig is created, the controller installs the external-secrets and keeps it in the desired state.
+        displayName: ExternalSecretsConfig
+        kind: ExternalSecretsConfig
+        name: externalsecretsconfigs.operator.openshift.io
+        version: v1alpha1
+      - description: |-
+          ExternalSecretsManager describes configuration and information about the deployments managed by
+          the operator. The name must be `cluster` to make ExternalSecretsManager a singleton that is, to
+          allow only one instance of ExternalSecretsManager per cluster.
+
+          ExternalSecretsManager is mainly for configuring the global options and enabling the features, which
+          serves as a common/centralized config for managing multiple controllers of the operator. The object
+          will be created during the operator installation.
+        displayName: ExternalSecretsManager
+        kind: ExternalSecretsManager
+        name: externalsecretsmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: GCRAccessToken generates a GCP access token that can be used
+          to authenticate with GCR.
+        displayName: GCRAccessToken
+        kind: GCRAccessToken
+        name: gcraccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: GeneratorState is the Schema for the generatorstates API.
+        displayName: GeneratorState
+        kind: GeneratorState
+        name: generatorstates.generators.external-secrets.io
+        version: v1alpha1
+      - description: GithubAccessToken generates a ghs_ access token
+        displayName: GithubAccessToken
+        kind: GithubAccessToken
+        name: githubaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: Grafana is the Schema for the grafanas API.
+        displayName: Grafana
+        kind: Grafana
+        name: grafanas.generators.external-secrets.io
+        version: v1alpha1
+      - description: MFA generates a new TOTP token that is compliant with RFC 6238.
+        displayName: MFA
+        kind: MFA
+        name: mfas.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          Password generates a random password based on the configuration parameters in spec. You can specify the length,
+          character set and other attributes.
+        displayName: Password
+        kind: Password
+        name: passwords.generators.external-secrets.io
+        version: v1alpha1
+      - description: PushSecret is the Schema for the pushsecrets API.
+        displayName: PushSecret
+        kind: PushSecret
+        name: pushsecrets.external-secrets.io
+        version: v1alpha1
+      - description: QuayAccessToken generates a Quay OAuth token for pulling/pushing
+          images.
+        displayName: QuayAccessToken
+        kind: QuayAccessToken
+        name: quayaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: SecretStore represents a secure external location for storing
+          secrets, which can be referenced as part of `storeRef` fields.
+        displayName: SecretStore
+        kind: SecretStore
+        name: secretstores.external-secrets.io
+        version: v1
+      - description: SSHKey generates SSH key pairs.
+        displayName: SSHKey
+        kind: SSHKey
+        name: sshkeys.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          STSSessionToken uses the GetSessionToken API to retrieve an authorization token. The authorization token is
+          valid for 12 hours. The authorizationToken returned is a base64 encoded string that can be decoded.
+          For more information, see GetSessionToken (https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html).
+        displayName: STSSessionToken
+        kind: STSSessionToken
+        name: stssessiontokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: UUID generates a version 1 UUID (for example, 6ba7b810-9dad-11d1-80b4-00c04fd430c8).
+        displayName: UUID
+        kind: UUID
+        name: uuids.generators.external-secrets.io
+        version: v1alpha1
+      - description: VaultDynamicSecret is the Schema for the vaultdynamicsecrets
+          API.
+        displayName: VaultDynamicSecret
+        kind: VaultDynamicSecret
+        name: vaultdynamicsecrets.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          Webhook connects to a third party API server to handle the secrets generation configuration parameters in spec. You
+          can specify the server, the token, and additional body parameters. See documentation for the full API specification
+          for requests and responses.
+        displayName: Webhook
+        kind: Webhook
+        name: webhooks.generators.external-secrets.io
+        version: v1alpha1
+    description: External Secrets Operator for Red Hat OpenShift deploys and manages
+      `external-secrets` application in OpenShift clusters. `external-secrets` provides
+      an uniform interface to fetch secrets stored in external providers like  AWS
+      Secrets Manager, HashiCorp Vault, Google Secrets Manager, Azure Key Vault, IBM
+      Cloud Secrets Manager to name a few, stores them as secrets in OpenShift. It
+      provides APIs to define authentication and the details of the secret to fetch.
+    displayName: External Secrets Operator for Red Hat OpenShift
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - secrets
+    - external-secrets
+    - external-secrets-operator
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/security_and_compliance/external-secrets-operator-for-red-hat-openshift
+    - name: External Secrets Operator
+      url: https://github.com/openshift/external-secrets-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat, Inc.
+relatedImages:
+- image: registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:1c7e9ddf3c6bf763ca04aeb1896ebb6ce8e70baed961c72bf81a26d33efa6e7d
+  name: bitwarden-sdk-server
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:024c26fc77e759f23408736c1d726064916e4588dcbbf90d76c7fc5c0b5ca0d1
+  name: ""
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8
+  name: ""
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:9d2fde3c6e71472f781020c758e33036c1c87117cc530db72602bc6dc5b92174
+  name: external-secrets
+schema: olm.bundle

--- a/catalogs/v4.19/catalog/openshift-external-secrets-operator/channel.yaml
+++ b/catalogs/v4.19/catalog/openshift-external-secrets-operator/channel.yaml
@@ -19,6 +19,9 @@ schema: olm.channel
 entries:
 - name: openshift-external-secrets-operator.v1.1.0
   skipRange: '<1.1.0'
+- name: openshift-external-secrets-operator.v1.1.1
+  replaces: openshift-external-secrets-operator.v1.1.0
+  skipRange: '>=1.1.0 <1.1.1'
 name: stable-v1.1
 package: openshift-external-secrets-operator
 schema: olm.channel

--- a/catalogs/v4.20/catalog/openshift-external-secrets-operator/bundle-v1.1.1.yaml
+++ b/catalogs/v4.20/catalog/openshift-external-secrets-operator/bundle-v1.1.1.yaml
@@ -1,0 +1,605 @@
+---
+image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:024c26fc77e759f23408736c1d726064916e4588dcbbf90d76c7fc5c0b5ca0d1
+name: openshift-external-secrets-operator.v1.1.1
+package: openshift-external-secrets-operator
+properties:
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterExternalSecret
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterExternalSecret
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterPushSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterSecretStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterSecretStore
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ExternalSecret
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ExternalSecret
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: PushSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: SecretStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: SecretStore
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ACRAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: CloudsmithAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ClusterGenerator
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ECRAuthorizationToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GCRAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GeneratorState
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GithubAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Grafana
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: MFA
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Password
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: QuayAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: SSHKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: STSSessionToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: UUID
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: VaultDynamicSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Webhook
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ExternalSecretsConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ExternalSecretsManager
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-external-secrets-operator
+    version: 1.1.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ClusterExternalSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "secret-cluster"
+            },
+            "spec": {
+              "externalSecretSpec": {
+                "data": [
+                  {
+                    "remoteRef": {
+                      "key": "gcp-secret"
+                    },
+                    "secretKey": "key"
+                  }
+                ],
+                "refreshInterval": "1h",
+                "secretStoreRef": {
+                  "kind": "ClusterSecretStore",
+                  "name": "gcp-cluster-secretstore"
+                },
+                "target": {
+                  "creationPolicy": "Owner",
+                  "name": "gcp-secret-k8s"
+                }
+              },
+              "namespaceSelector": {
+                "matchLabels": {
+                  "app.kubernetes.io/managed-by": "external-secrets-operator"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ClusterSecretStore",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "gcp-cluster-secretstore"
+            },
+            "spec": {
+              "provider": {
+                "gcpsm": {
+                  "auth": {
+                    "secretRef": {
+                      "secretAccessKeySecretRef": {
+                        "key": "secret-access-key.json",
+                        "name": "gcp-creds",
+                        "namespace": "external-secrets"
+                      }
+                    }
+                  },
+                  "projectID": "openshift-sample-project"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ExternalSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "gcp-secret",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "data": [
+                {
+                  "remoteRef": {
+                    "key": "gcp-secret",
+                    "property": "Key"
+                  },
+                  "secretKey": "Key"
+                }
+              ],
+              "refreshInterval": "1h",
+              "secretStoreRef": {
+                "kind": "SecretStore",
+                "name": "secretstore"
+              },
+              "target": {
+                "creationPolicy": "Owner",
+                "name": "k8s-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "SecretStore",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/disable-maintenance-checks": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "secretstore",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "provider": {
+                "gcpsm": {
+                  "auth": {
+                    "secretRef": {
+                      "secretAccessKeySecretRef": {
+                        "key": "secret-access-key.json",
+                        "name": "gcp-creds"
+                      }
+                    }
+                  },
+                  "projectID": "openshift-sample-project"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1alpha1",
+            "kind": "PushSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "pushsecret-sample",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "config": {
+                "gcp": {
+                  "projectID": "openshift-sample-project",
+                  "secret": {
+                    "name": "test",
+                    "replicationPolicy": "automatic",
+                    "version": "latest"
+                  }
+                }
+              },
+              "secretStoreRefs": [
+                {
+                  "kind": "ClusterSecretStore",
+                  "name": "gcp-cluster-secretstore"
+                }
+              ],
+              "selector": {
+                "secret": {
+                  "name": "gcp-secret-k8s"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "generators.external-secrets.io/v1alpha1",
+            "kind": "Password",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "password-sample",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "excludeLowercase": false,
+              "excludeNumbers": false,
+              "excludeUppercase": false,
+              "includeSymbols": true,
+              "length": 20
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ExternalSecretsConfig",
+            "metadata": {
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "cluster"
+            },
+            "spec": {}
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ExternalSecretsManager",
+            "metadata": {
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "cluster"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8
+      createdAt: 2026-08-11T11:24:58
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.1.0 <1.1.1'
+      operator.openshift.io/uninstall-message: The External Secrets Operator for Red
+        Hat OpenShift will be removed from external-secrets-operator namespace. If
+        your Operator configured any off-cluster resources, these will continue to
+        run and require manual cleanup. All operands created by the operator will
+        need to be manually cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/external_secrets_operator/external-secrets-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: external-secrets-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.39.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/openshift/external-secrets-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: |-
+          ACRAccessToken returns an Azure Container Registry token that can be used for pushing/pulling images.
+          Note: by default it will return an ACR Refresh Token with full access (depending on the identity).
+          This can be scoped down to the repository level using .spec.scope. In case scope is defined it will return an ACR Access Token.
+
+          See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md
+        displayName: ACRAccessToken
+        kind: ACRAccessToken
+        name: acraccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: CloudsmithAccessToken generates Cloudsmith access token using
+          OIDC authentication
+        displayName: CloudsmithAccessToken
+        kind: CloudsmithAccessToken
+        name: cloudsmithaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: ClusterExternalSecret is the Schema for the clusterexternalsecrets
+          API.
+        displayName: ClusterExternalSecret
+        kind: ClusterExternalSecret
+        name: clusterexternalsecrets.external-secrets.io
+        version: v1
+      - description: ClusterGenerator represents a cluster-wide generator which can
+          be referenced as part of `generatorRef` fields.
+        displayName: ClusterGenerator
+        kind: ClusterGenerator
+        name: clustergenerators.generators.external-secrets.io
+        version: v1alpha1
+      - description: ClusterPushSecret is the Schema for the clusterpushsecrets API.
+        displayName: ClusterPushSecret
+        kind: ClusterPushSecret
+        name: clusterpushsecrets.external-secrets.io
+        version: v1alpha1
+      - description: ClusterSecretStore represents a secure external location for
+          storing secrets, which can be referenced as part of `storeRef` fields.
+        displayName: ClusterSecretStore
+        kind: ClusterSecretStore
+        name: clustersecretstores.external-secrets.io
+        version: v1
+      - description: |-
+          ECRAuthorizationToken uses the GetAuthorizationToken API to retrieve an authorization token. The authorization
+          token is valid for 12 hours. The authorizationToken returned is a base64 encoded string that can be decoded and
+          used in a Docker login command to authenticate to a registry. For more information, see Registry authentication
+          (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth)
+          in the Amazon Elastic Container Registry User Guide.
+        displayName: ECRAuthorizationToken
+        kind: ECRAuthorizationToken
+        name: ecrauthorizationtokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: ExternalSecret is the Schema for the external-secrets API.
+        displayName: ExternalSecret
+        kind: ExternalSecret
+        name: externalsecrets.external-secrets.io
+        version: v1
+      - description: |-
+          ExternalSecretsConfig describes configuration and information about the managed external-secrets deployment.
+          The name must be `cluster` as ExternalSecretsConfig is a singleton, allowing only one instance per cluster.
+
+          When an ExternalSecretsConfig is created, the controller installs the external-secrets and keeps it in the desired state.
+        displayName: ExternalSecretsConfig
+        kind: ExternalSecretsConfig
+        name: externalsecretsconfigs.operator.openshift.io
+        version: v1alpha1
+      - description: |-
+          ExternalSecretsManager describes configuration and information about the deployments managed by
+          the operator. The name must be `cluster` to make ExternalSecretsManager a singleton that is, to
+          allow only one instance of ExternalSecretsManager per cluster.
+
+          ExternalSecretsManager is mainly for configuring the global options and enabling the features, which
+          serves as a common/centralized config for managing multiple controllers of the operator. The object
+          will be created during the operator installation.
+        displayName: ExternalSecretsManager
+        kind: ExternalSecretsManager
+        name: externalsecretsmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: GCRAccessToken generates a GCP access token that can be used
+          to authenticate with GCR.
+        displayName: GCRAccessToken
+        kind: GCRAccessToken
+        name: gcraccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: GeneratorState is the Schema for the generatorstates API.
+        displayName: GeneratorState
+        kind: GeneratorState
+        name: generatorstates.generators.external-secrets.io
+        version: v1alpha1
+      - description: GithubAccessToken generates a ghs_ access token
+        displayName: GithubAccessToken
+        kind: GithubAccessToken
+        name: githubaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: Grafana is the Schema for the grafanas API.
+        displayName: Grafana
+        kind: Grafana
+        name: grafanas.generators.external-secrets.io
+        version: v1alpha1
+      - description: MFA generates a new TOTP token that is compliant with RFC 6238.
+        displayName: MFA
+        kind: MFA
+        name: mfas.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          Password generates a random password based on the configuration parameters in spec. You can specify the length,
+          character set and other attributes.
+        displayName: Password
+        kind: Password
+        name: passwords.generators.external-secrets.io
+        version: v1alpha1
+      - description: PushSecret is the Schema for the pushsecrets API.
+        displayName: PushSecret
+        kind: PushSecret
+        name: pushsecrets.external-secrets.io
+        version: v1alpha1
+      - description: QuayAccessToken generates a Quay OAuth token for pulling/pushing
+          images.
+        displayName: QuayAccessToken
+        kind: QuayAccessToken
+        name: quayaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: SecretStore represents a secure external location for storing
+          secrets, which can be referenced as part of `storeRef` fields.
+        displayName: SecretStore
+        kind: SecretStore
+        name: secretstores.external-secrets.io
+        version: v1
+      - description: SSHKey generates SSH key pairs.
+        displayName: SSHKey
+        kind: SSHKey
+        name: sshkeys.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          STSSessionToken uses the GetSessionToken API to retrieve an authorization token. The authorization token is
+          valid for 12 hours. The authorizationToken returned is a base64 encoded string that can be decoded.
+          For more information, see GetSessionToken (https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html).
+        displayName: STSSessionToken
+        kind: STSSessionToken
+        name: stssessiontokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: UUID generates a version 1 UUID (for example, 6ba7b810-9dad-11d1-80b4-00c04fd430c8).
+        displayName: UUID
+        kind: UUID
+        name: uuids.generators.external-secrets.io
+        version: v1alpha1
+      - description: VaultDynamicSecret is the Schema for the vaultdynamicsecrets
+          API.
+        displayName: VaultDynamicSecret
+        kind: VaultDynamicSecret
+        name: vaultdynamicsecrets.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          Webhook connects to a third party API server to handle the secrets generation configuration parameters in spec. You
+          can specify the server, the token, and additional body parameters. See documentation for the full API specification
+          for requests and responses.
+        displayName: Webhook
+        kind: Webhook
+        name: webhooks.generators.external-secrets.io
+        version: v1alpha1
+    description: External Secrets Operator for Red Hat OpenShift deploys and manages
+      `external-secrets` application in OpenShift clusters. `external-secrets` provides
+      an uniform interface to fetch secrets stored in external providers like  AWS
+      Secrets Manager, HashiCorp Vault, Google Secrets Manager, Azure Key Vault, IBM
+      Cloud Secrets Manager to name a few, stores them as secrets in OpenShift. It
+      provides APIs to define authentication and the details of the secret to fetch.
+    displayName: External Secrets Operator for Red Hat OpenShift
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - secrets
+    - external-secrets
+    - external-secrets-operator
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/security_and_compliance/external-secrets-operator-for-red-hat-openshift
+    - name: External Secrets Operator
+      url: https://github.com/openshift/external-secrets-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat, Inc.
+relatedImages:
+- image: registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:1c7e9ddf3c6bf763ca04aeb1896ebb6ce8e70baed961c72bf81a26d33efa6e7d
+  name: bitwarden-sdk-server
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:024c26fc77e759f23408736c1d726064916e4588dcbbf90d76c7fc5c0b5ca0d1
+  name: ""
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8
+  name: ""
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:9d2fde3c6e71472f781020c758e33036c1c87117cc530db72602bc6dc5b92174
+  name: external-secrets
+schema: olm.bundle

--- a/catalogs/v4.20/catalog/openshift-external-secrets-operator/channel.yaml
+++ b/catalogs/v4.20/catalog/openshift-external-secrets-operator/channel.yaml
@@ -26,6 +26,9 @@ entries:
 - name: openshift-external-secrets-operator.v1.1.0
   replaces: external-secrets-operator.v1.0.0
   skipRange: '>=1.0.0 <1.1.0'
+- name: openshift-external-secrets-operator.v1.1.1
+  replaces: openshift-external-secrets-operator.v1.1.0
+  skipRange: '>=1.1.0 <1.1.1'
 name: stable-v1.1
 package: openshift-external-secrets-operator
 schema: olm.channel

--- a/catalogs/v4.21/catalog/openshift-external-secrets-operator/bundle-v1.1.1.yaml
+++ b/catalogs/v4.21/catalog/openshift-external-secrets-operator/bundle-v1.1.1.yaml
@@ -1,0 +1,605 @@
+---
+image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:024c26fc77e759f23408736c1d726064916e4588dcbbf90d76c7fc5c0b5ca0d1
+name: openshift-external-secrets-operator.v1.1.1
+package: openshift-external-secrets-operator
+properties:
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterExternalSecret
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterExternalSecret
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterPushSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterSecretStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterSecretStore
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ExternalSecret
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ExternalSecret
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: PushSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: SecretStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: SecretStore
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ACRAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: CloudsmithAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ClusterGenerator
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ECRAuthorizationToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GCRAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GeneratorState
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GithubAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Grafana
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: MFA
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Password
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: QuayAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: SSHKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: STSSessionToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: UUID
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: VaultDynamicSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Webhook
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ExternalSecretsConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ExternalSecretsManager
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-external-secrets-operator
+    version: 1.1.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ClusterExternalSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "secret-cluster"
+            },
+            "spec": {
+              "externalSecretSpec": {
+                "data": [
+                  {
+                    "remoteRef": {
+                      "key": "gcp-secret"
+                    },
+                    "secretKey": "key"
+                  }
+                ],
+                "refreshInterval": "1h",
+                "secretStoreRef": {
+                  "kind": "ClusterSecretStore",
+                  "name": "gcp-cluster-secretstore"
+                },
+                "target": {
+                  "creationPolicy": "Owner",
+                  "name": "gcp-secret-k8s"
+                }
+              },
+              "namespaceSelector": {
+                "matchLabels": {
+                  "app.kubernetes.io/managed-by": "external-secrets-operator"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ClusterSecretStore",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "gcp-cluster-secretstore"
+            },
+            "spec": {
+              "provider": {
+                "gcpsm": {
+                  "auth": {
+                    "secretRef": {
+                      "secretAccessKeySecretRef": {
+                        "key": "secret-access-key.json",
+                        "name": "gcp-creds",
+                        "namespace": "external-secrets"
+                      }
+                    }
+                  },
+                  "projectID": "openshift-sample-project"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ExternalSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "gcp-secret",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "data": [
+                {
+                  "remoteRef": {
+                    "key": "gcp-secret",
+                    "property": "Key"
+                  },
+                  "secretKey": "Key"
+                }
+              ],
+              "refreshInterval": "1h",
+              "secretStoreRef": {
+                "kind": "SecretStore",
+                "name": "secretstore"
+              },
+              "target": {
+                "creationPolicy": "Owner",
+                "name": "k8s-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "SecretStore",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/disable-maintenance-checks": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "secretstore",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "provider": {
+                "gcpsm": {
+                  "auth": {
+                    "secretRef": {
+                      "secretAccessKeySecretRef": {
+                        "key": "secret-access-key.json",
+                        "name": "gcp-creds"
+                      }
+                    }
+                  },
+                  "projectID": "openshift-sample-project"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1alpha1",
+            "kind": "PushSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "pushsecret-sample",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "config": {
+                "gcp": {
+                  "projectID": "openshift-sample-project",
+                  "secret": {
+                    "name": "test",
+                    "replicationPolicy": "automatic",
+                    "version": "latest"
+                  }
+                }
+              },
+              "secretStoreRefs": [
+                {
+                  "kind": "ClusterSecretStore",
+                  "name": "gcp-cluster-secretstore"
+                }
+              ],
+              "selector": {
+                "secret": {
+                  "name": "gcp-secret-k8s"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "generators.external-secrets.io/v1alpha1",
+            "kind": "Password",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "password-sample",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "excludeLowercase": false,
+              "excludeNumbers": false,
+              "excludeUppercase": false,
+              "includeSymbols": true,
+              "length": 20
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ExternalSecretsConfig",
+            "metadata": {
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "cluster"
+            },
+            "spec": {}
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ExternalSecretsManager",
+            "metadata": {
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "cluster"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8
+      createdAt: 2026-08-11T11:24:58
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.1.0 <1.1.1'
+      operator.openshift.io/uninstall-message: The External Secrets Operator for Red
+        Hat OpenShift will be removed from external-secrets-operator namespace. If
+        your Operator configured any off-cluster resources, these will continue to
+        run and require manual cleanup. All operands created by the operator will
+        need to be manually cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/external_secrets_operator/external-secrets-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: external-secrets-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.39.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/openshift/external-secrets-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: |-
+          ACRAccessToken returns an Azure Container Registry token that can be used for pushing/pulling images.
+          Note: by default it will return an ACR Refresh Token with full access (depending on the identity).
+          This can be scoped down to the repository level using .spec.scope. In case scope is defined it will return an ACR Access Token.
+
+          See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md
+        displayName: ACRAccessToken
+        kind: ACRAccessToken
+        name: acraccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: CloudsmithAccessToken generates Cloudsmith access token using
+          OIDC authentication
+        displayName: CloudsmithAccessToken
+        kind: CloudsmithAccessToken
+        name: cloudsmithaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: ClusterExternalSecret is the Schema for the clusterexternalsecrets
+          API.
+        displayName: ClusterExternalSecret
+        kind: ClusterExternalSecret
+        name: clusterexternalsecrets.external-secrets.io
+        version: v1
+      - description: ClusterGenerator represents a cluster-wide generator which can
+          be referenced as part of `generatorRef` fields.
+        displayName: ClusterGenerator
+        kind: ClusterGenerator
+        name: clustergenerators.generators.external-secrets.io
+        version: v1alpha1
+      - description: ClusterPushSecret is the Schema for the clusterpushsecrets API.
+        displayName: ClusterPushSecret
+        kind: ClusterPushSecret
+        name: clusterpushsecrets.external-secrets.io
+        version: v1alpha1
+      - description: ClusterSecretStore represents a secure external location for
+          storing secrets, which can be referenced as part of `storeRef` fields.
+        displayName: ClusterSecretStore
+        kind: ClusterSecretStore
+        name: clustersecretstores.external-secrets.io
+        version: v1
+      - description: |-
+          ECRAuthorizationToken uses the GetAuthorizationToken API to retrieve an authorization token. The authorization
+          token is valid for 12 hours. The authorizationToken returned is a base64 encoded string that can be decoded and
+          used in a Docker login command to authenticate to a registry. For more information, see Registry authentication
+          (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth)
+          in the Amazon Elastic Container Registry User Guide.
+        displayName: ECRAuthorizationToken
+        kind: ECRAuthorizationToken
+        name: ecrauthorizationtokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: ExternalSecret is the Schema for the external-secrets API.
+        displayName: ExternalSecret
+        kind: ExternalSecret
+        name: externalsecrets.external-secrets.io
+        version: v1
+      - description: |-
+          ExternalSecretsConfig describes configuration and information about the managed external-secrets deployment.
+          The name must be `cluster` as ExternalSecretsConfig is a singleton, allowing only one instance per cluster.
+
+          When an ExternalSecretsConfig is created, the controller installs the external-secrets and keeps it in the desired state.
+        displayName: ExternalSecretsConfig
+        kind: ExternalSecretsConfig
+        name: externalsecretsconfigs.operator.openshift.io
+        version: v1alpha1
+      - description: |-
+          ExternalSecretsManager describes configuration and information about the deployments managed by
+          the operator. The name must be `cluster` to make ExternalSecretsManager a singleton that is, to
+          allow only one instance of ExternalSecretsManager per cluster.
+
+          ExternalSecretsManager is mainly for configuring the global options and enabling the features, which
+          serves as a common/centralized config for managing multiple controllers of the operator. The object
+          will be created during the operator installation.
+        displayName: ExternalSecretsManager
+        kind: ExternalSecretsManager
+        name: externalsecretsmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: GCRAccessToken generates a GCP access token that can be used
+          to authenticate with GCR.
+        displayName: GCRAccessToken
+        kind: GCRAccessToken
+        name: gcraccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: GeneratorState is the Schema for the generatorstates API.
+        displayName: GeneratorState
+        kind: GeneratorState
+        name: generatorstates.generators.external-secrets.io
+        version: v1alpha1
+      - description: GithubAccessToken generates a ghs_ access token
+        displayName: GithubAccessToken
+        kind: GithubAccessToken
+        name: githubaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: Grafana is the Schema for the grafanas API.
+        displayName: Grafana
+        kind: Grafana
+        name: grafanas.generators.external-secrets.io
+        version: v1alpha1
+      - description: MFA generates a new TOTP token that is compliant with RFC 6238.
+        displayName: MFA
+        kind: MFA
+        name: mfas.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          Password generates a random password based on the configuration parameters in spec. You can specify the length,
+          character set and other attributes.
+        displayName: Password
+        kind: Password
+        name: passwords.generators.external-secrets.io
+        version: v1alpha1
+      - description: PushSecret is the Schema for the pushsecrets API.
+        displayName: PushSecret
+        kind: PushSecret
+        name: pushsecrets.external-secrets.io
+        version: v1alpha1
+      - description: QuayAccessToken generates a Quay OAuth token for pulling/pushing
+          images.
+        displayName: QuayAccessToken
+        kind: QuayAccessToken
+        name: quayaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: SecretStore represents a secure external location for storing
+          secrets, which can be referenced as part of `storeRef` fields.
+        displayName: SecretStore
+        kind: SecretStore
+        name: secretstores.external-secrets.io
+        version: v1
+      - description: SSHKey generates SSH key pairs.
+        displayName: SSHKey
+        kind: SSHKey
+        name: sshkeys.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          STSSessionToken uses the GetSessionToken API to retrieve an authorization token. The authorization token is
+          valid for 12 hours. The authorizationToken returned is a base64 encoded string that can be decoded.
+          For more information, see GetSessionToken (https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html).
+        displayName: STSSessionToken
+        kind: STSSessionToken
+        name: stssessiontokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: UUID generates a version 1 UUID (for example, 6ba7b810-9dad-11d1-80b4-00c04fd430c8).
+        displayName: UUID
+        kind: UUID
+        name: uuids.generators.external-secrets.io
+        version: v1alpha1
+      - description: VaultDynamicSecret is the Schema for the vaultdynamicsecrets
+          API.
+        displayName: VaultDynamicSecret
+        kind: VaultDynamicSecret
+        name: vaultdynamicsecrets.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          Webhook connects to a third party API server to handle the secrets generation configuration parameters in spec. You
+          can specify the server, the token, and additional body parameters. See documentation for the full API specification
+          for requests and responses.
+        displayName: Webhook
+        kind: Webhook
+        name: webhooks.generators.external-secrets.io
+        version: v1alpha1
+    description: External Secrets Operator for Red Hat OpenShift deploys and manages
+      `external-secrets` application in OpenShift clusters. `external-secrets` provides
+      an uniform interface to fetch secrets stored in external providers like  AWS
+      Secrets Manager, HashiCorp Vault, Google Secrets Manager, Azure Key Vault, IBM
+      Cloud Secrets Manager to name a few, stores them as secrets in OpenShift. It
+      provides APIs to define authentication and the details of the secret to fetch.
+    displayName: External Secrets Operator for Red Hat OpenShift
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - secrets
+    - external-secrets
+    - external-secrets-operator
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/security_and_compliance/external-secrets-operator-for-red-hat-openshift
+    - name: External Secrets Operator
+      url: https://github.com/openshift/external-secrets-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat, Inc.
+relatedImages:
+- image: registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:1c7e9ddf3c6bf763ca04aeb1896ebb6ce8e70baed961c72bf81a26d33efa6e7d
+  name: bitwarden-sdk-server
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:024c26fc77e759f23408736c1d726064916e4588dcbbf90d76c7fc5c0b5ca0d1
+  name: ""
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8
+  name: ""
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:9d2fde3c6e71472f781020c758e33036c1c87117cc530db72602bc6dc5b92174
+  name: external-secrets
+schema: olm.bundle

--- a/catalogs/v4.21/catalog/openshift-external-secrets-operator/channel.yaml
+++ b/catalogs/v4.21/catalog/openshift-external-secrets-operator/channel.yaml
@@ -26,6 +26,9 @@ entries:
 - name: openshift-external-secrets-operator.v1.1.0
   replaces: external-secrets-operator.v1.0.0
   skipRange: '>=1.0.0 <1.1.0'
+- name: openshift-external-secrets-operator.v1.1.1
+  replaces: openshift-external-secrets-operator.v1.1.0
+  skipRange: '>=1.1.0 <1.1.1'
 name: stable-v1.1
 package: openshift-external-secrets-operator
 schema: olm.channel

--- a/catalogs/v4.22/catalog/openshift-external-secrets-operator/bundle-v1.1.1.yaml
+++ b/catalogs/v4.22/catalog/openshift-external-secrets-operator/bundle-v1.1.1.yaml
@@ -1,0 +1,605 @@
+---
+image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:024c26fc77e759f23408736c1d726064916e4588dcbbf90d76c7fc5c0b5ca0d1
+name: openshift-external-secrets-operator.v1.1.1
+package: openshift-external-secrets-operator
+properties:
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterExternalSecret
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterExternalSecret
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterPushSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterSecretStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ClusterSecretStore
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ExternalSecret
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: ExternalSecret
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: PushSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: SecretStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: external-secrets.io
+    kind: SecretStore
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ACRAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: CloudsmithAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ClusterGenerator
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: ECRAuthorizationToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GCRAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GeneratorState
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: GithubAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Grafana
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: MFA
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Password
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: QuayAccessToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: SSHKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: STSSessionToken
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: UUID
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: VaultDynamicSecret
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: generators.external-secrets.io
+    kind: Webhook
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ExternalSecretsConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ExternalSecretsManager
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-external-secrets-operator
+    version: 1.1.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ClusterExternalSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "secret-cluster"
+            },
+            "spec": {
+              "externalSecretSpec": {
+                "data": [
+                  {
+                    "remoteRef": {
+                      "key": "gcp-secret"
+                    },
+                    "secretKey": "key"
+                  }
+                ],
+                "refreshInterval": "1h",
+                "secretStoreRef": {
+                  "kind": "ClusterSecretStore",
+                  "name": "gcp-cluster-secretstore"
+                },
+                "target": {
+                  "creationPolicy": "Owner",
+                  "name": "gcp-secret-k8s"
+                }
+              },
+              "namespaceSelector": {
+                "matchLabels": {
+                  "app.kubernetes.io/managed-by": "external-secrets-operator"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ClusterSecretStore",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "gcp-cluster-secretstore"
+            },
+            "spec": {
+              "provider": {
+                "gcpsm": {
+                  "auth": {
+                    "secretRef": {
+                      "secretAccessKeySecretRef": {
+                        "key": "secret-access-key.json",
+                        "name": "gcp-creds",
+                        "namespace": "external-secrets"
+                      }
+                    }
+                  },
+                  "projectID": "openshift-sample-project"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "ExternalSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "gcp-secret",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "data": [
+                {
+                  "remoteRef": {
+                    "key": "gcp-secret",
+                    "property": "Key"
+                  },
+                  "secretKey": "Key"
+                }
+              ],
+              "refreshInterval": "1h",
+              "secretStoreRef": {
+                "kind": "SecretStore",
+                "name": "secretstore"
+              },
+              "target": {
+                "creationPolicy": "Owner",
+                "name": "k8s-secret"
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1",
+            "kind": "SecretStore",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/disable-maintenance-checks": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "secretstore",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "provider": {
+                "gcpsm": {
+                  "auth": {
+                    "secretRef": {
+                      "secretAccessKeySecretRef": {
+                        "key": "secret-access-key.json",
+                        "name": "gcp-creds"
+                      }
+                    }
+                  },
+                  "projectID": "openshift-sample-project"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "external-secrets.io/v1alpha1",
+            "kind": "PushSecret",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "pushsecret-sample",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "config": {
+                "gcp": {
+                  "projectID": "openshift-sample-project",
+                  "secret": {
+                    "name": "test",
+                    "replicationPolicy": "automatic",
+                    "version": "latest"
+                  }
+                }
+              },
+              "secretStoreRefs": [
+                {
+                  "kind": "ClusterSecretStore",
+                  "name": "gcp-cluster-secretstore"
+                }
+              ],
+              "selector": {
+                "secret": {
+                  "name": "gcp-secret-k8s"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "generators.external-secrets.io/v1alpha1",
+            "kind": "Password",
+            "metadata": {
+              "annotations": {
+                "external-secrets.io/example": "true"
+              },
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "password-sample",
+              "namespace": "external-secrets"
+            },
+            "spec": {
+              "excludeLowercase": false,
+              "excludeNumbers": false,
+              "excludeUppercase": false,
+              "includeSymbols": true,
+              "length": 20
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ExternalSecretsConfig",
+            "metadata": {
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "cluster"
+            },
+            "spec": {}
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ExternalSecretsManager",
+            "metadata": {
+              "labels": {
+                "app": "external-secrets-operator"
+              },
+              "name": "cluster"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Security
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8
+      createdAt: 2026-08-11T11:24:58
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.1.0 <1.1.1'
+      operator.openshift.io/uninstall-message: The External Secrets Operator for Red
+        Hat OpenShift will be removed from external-secrets-operator namespace. If
+        your Operator configured any off-cluster resources, these will continue to
+        run and require manual cleanup. All operands created by the operator will
+        need to be manually cleaned up. Please refer to https://docs.openshift.com/container-platform/latest/security/external_secrets_operator/external-secrets-operator-uninstall.html
+        for additional steps.
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: external-secrets-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.39.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/openshift/external-secrets-operator
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: |-
+          ACRAccessToken returns an Azure Container Registry token that can be used for pushing/pulling images.
+          Note: by default it will return an ACR Refresh Token with full access (depending on the identity).
+          This can be scoped down to the repository level using .spec.scope. In case scope is defined it will return an ACR Access Token.
+
+          See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md
+        displayName: ACRAccessToken
+        kind: ACRAccessToken
+        name: acraccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: CloudsmithAccessToken generates Cloudsmith access token using
+          OIDC authentication
+        displayName: CloudsmithAccessToken
+        kind: CloudsmithAccessToken
+        name: cloudsmithaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: ClusterExternalSecret is the Schema for the clusterexternalsecrets
+          API.
+        displayName: ClusterExternalSecret
+        kind: ClusterExternalSecret
+        name: clusterexternalsecrets.external-secrets.io
+        version: v1
+      - description: ClusterGenerator represents a cluster-wide generator which can
+          be referenced as part of `generatorRef` fields.
+        displayName: ClusterGenerator
+        kind: ClusterGenerator
+        name: clustergenerators.generators.external-secrets.io
+        version: v1alpha1
+      - description: ClusterPushSecret is the Schema for the clusterpushsecrets API.
+        displayName: ClusterPushSecret
+        kind: ClusterPushSecret
+        name: clusterpushsecrets.external-secrets.io
+        version: v1alpha1
+      - description: ClusterSecretStore represents a secure external location for
+          storing secrets, which can be referenced as part of `storeRef` fields.
+        displayName: ClusterSecretStore
+        kind: ClusterSecretStore
+        name: clustersecretstores.external-secrets.io
+        version: v1
+      - description: |-
+          ECRAuthorizationToken uses the GetAuthorizationToken API to retrieve an authorization token. The authorization
+          token is valid for 12 hours. The authorizationToken returned is a base64 encoded string that can be decoded and
+          used in a Docker login command to authenticate to a registry. For more information, see Registry authentication
+          (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth)
+          in the Amazon Elastic Container Registry User Guide.
+        displayName: ECRAuthorizationToken
+        kind: ECRAuthorizationToken
+        name: ecrauthorizationtokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: ExternalSecret is the Schema for the external-secrets API.
+        displayName: ExternalSecret
+        kind: ExternalSecret
+        name: externalsecrets.external-secrets.io
+        version: v1
+      - description: |-
+          ExternalSecretsConfig describes configuration and information about the managed external-secrets deployment.
+          The name must be `cluster` as ExternalSecretsConfig is a singleton, allowing only one instance per cluster.
+
+          When an ExternalSecretsConfig is created, the controller installs the external-secrets and keeps it in the desired state.
+        displayName: ExternalSecretsConfig
+        kind: ExternalSecretsConfig
+        name: externalsecretsconfigs.operator.openshift.io
+        version: v1alpha1
+      - description: |-
+          ExternalSecretsManager describes configuration and information about the deployments managed by
+          the operator. The name must be `cluster` to make ExternalSecretsManager a singleton that is, to
+          allow only one instance of ExternalSecretsManager per cluster.
+
+          ExternalSecretsManager is mainly for configuring the global options and enabling the features, which
+          serves as a common/centralized config for managing multiple controllers of the operator. The object
+          will be created during the operator installation.
+        displayName: ExternalSecretsManager
+        kind: ExternalSecretsManager
+        name: externalsecretsmanagers.operator.openshift.io
+        version: v1alpha1
+      - description: GCRAccessToken generates a GCP access token that can be used
+          to authenticate with GCR.
+        displayName: GCRAccessToken
+        kind: GCRAccessToken
+        name: gcraccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: GeneratorState is the Schema for the generatorstates API.
+        displayName: GeneratorState
+        kind: GeneratorState
+        name: generatorstates.generators.external-secrets.io
+        version: v1alpha1
+      - description: GithubAccessToken generates a ghs_ access token
+        displayName: GithubAccessToken
+        kind: GithubAccessToken
+        name: githubaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: Grafana is the Schema for the grafanas API.
+        displayName: Grafana
+        kind: Grafana
+        name: grafanas.generators.external-secrets.io
+        version: v1alpha1
+      - description: MFA generates a new TOTP token that is compliant with RFC 6238.
+        displayName: MFA
+        kind: MFA
+        name: mfas.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          Password generates a random password based on the configuration parameters in spec. You can specify the length,
+          character set and other attributes.
+        displayName: Password
+        kind: Password
+        name: passwords.generators.external-secrets.io
+        version: v1alpha1
+      - description: PushSecret is the Schema for the pushsecrets API.
+        displayName: PushSecret
+        kind: PushSecret
+        name: pushsecrets.external-secrets.io
+        version: v1alpha1
+      - description: QuayAccessToken generates a Quay OAuth token for pulling/pushing
+          images.
+        displayName: QuayAccessToken
+        kind: QuayAccessToken
+        name: quayaccesstokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: SecretStore represents a secure external location for storing
+          secrets, which can be referenced as part of `storeRef` fields.
+        displayName: SecretStore
+        kind: SecretStore
+        name: secretstores.external-secrets.io
+        version: v1
+      - description: SSHKey generates SSH key pairs.
+        displayName: SSHKey
+        kind: SSHKey
+        name: sshkeys.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          STSSessionToken uses the GetSessionToken API to retrieve an authorization token. The authorization token is
+          valid for 12 hours. The authorizationToken returned is a base64 encoded string that can be decoded.
+          For more information, see GetSessionToken (https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html).
+        displayName: STSSessionToken
+        kind: STSSessionToken
+        name: stssessiontokens.generators.external-secrets.io
+        version: v1alpha1
+      - description: UUID generates a version 1 UUID (for example, 6ba7b810-9dad-11d1-80b4-00c04fd430c8).
+        displayName: UUID
+        kind: UUID
+        name: uuids.generators.external-secrets.io
+        version: v1alpha1
+      - description: VaultDynamicSecret is the Schema for the vaultdynamicsecrets
+          API.
+        displayName: VaultDynamicSecret
+        kind: VaultDynamicSecret
+        name: vaultdynamicsecrets.generators.external-secrets.io
+        version: v1alpha1
+      - description: |-
+          Webhook connects to a third party API server to handle the secrets generation configuration parameters in spec. You
+          can specify the server, the token, and additional body parameters. See documentation for the full API specification
+          for requests and responses.
+        displayName: Webhook
+        kind: Webhook
+        name: webhooks.generators.external-secrets.io
+        version: v1alpha1
+    description: External Secrets Operator for Red Hat OpenShift deploys and manages
+      `external-secrets` application in OpenShift clusters. `external-secrets` provides
+      an uniform interface to fetch secrets stored in external providers like  AWS
+      Secrets Manager, HashiCorp Vault, Google Secrets Manager, Azure Key Vault, IBM
+      Cloud Secrets Manager to name a few, stores them as secrets in OpenShift. It
+      provides APIs to define authentication and the details of the secret to fetch.
+    displayName: External Secrets Operator for Red Hat OpenShift
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - secrets
+    - external-secrets
+    - external-secrets-operator
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/security_and_compliance/external-secrets-operator-for-red-hat-openshift
+    - name: External Secrets Operator
+      url: https://github.com/openshift/external-secrets-operator/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    minKubeVersion: 1.31.0
+    provider:
+      name: Red Hat, Inc.
+relatedImages:
+- image: registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:1c7e9ddf3c6bf763ca04aeb1896ebb6ce8e70baed961c72bf81a26d33efa6e7d
+  name: bitwarden-sdk-server
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:024c26fc77e759f23408736c1d726064916e4588dcbbf90d76c7fc5c0b5ca0d1
+  name: ""
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8
+  name: ""
+- image: registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:9d2fde3c6e71472f781020c758e33036c1c87117cc530db72602bc6dc5b92174
+  name: external-secrets
+schema: olm.bundle

--- a/catalogs/v4.22/catalog/openshift-external-secrets-operator/channel.yaml
+++ b/catalogs/v4.22/catalog/openshift-external-secrets-operator/channel.yaml
@@ -26,6 +26,9 @@ entries:
 - name: openshift-external-secrets-operator.v1.1.0
   replaces: external-secrets-operator.v1.0.0
   skipRange: '>=1.0.0 <1.1.0'
+- name: openshift-external-secrets-operator.v1.1.1
+  replaces: openshift-external-secrets-operator.v1.1.0
+  skipRange: '>=1.1.0 <1.1.1'
 name: stable-v1.1
 package: openshift-external-secrets-operator
 schema: olm.channel


### PR DESCRIPTION
The PR is for updating the staged bundle image of v1.1.1 in 4.18 - 4.22 OCP catalogs.

```
$ podman inspect registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-bundle@sha256:024c26fc77e759f23408736c1d726064916e4588dcbbf90d76c7fc5c0b5ca0d1 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/087b30871871dbfb618f26bd3578172b046d6131",
                    "version": "v1.1.1"
```