### PR TITLE
ESO-523: Updates the bundle with the v1.1.1 prod image

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,10 +4,10 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 # external-secrets operand image digest.
-EXTERNAL_SECRETS_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:9d2fde3c6e71472f781020c758e33036c1c87117cc530db72602bc6dc5b92174
+EXTERNAL_SECRETS_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:d3ea7ebb3f3dd8df88ab575e06a670cebe049d38c0783d1104196fe042e2dc45
 
 # bitwarden-sdk-server operand image digest.
-BITWARDEN_SDK_SERVER_IMAGE=registry.stage.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:1c7e9ddf3c6bf763ca04aeb1896ebb6ce8e70baed961c72bf81a26d33efa6e7d
+BITWARDEN_SDK_SERVER_IMAGE=registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:ecdb95c0cb868d273a55675ac39f6ce53cad353da14c74eca040df24bbada721
 
 # external-secrets-operator image digest.
-EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.stage.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:7b0688264405b566f7f6c2d308d2d6cfe680236b7f7410bc779e9aa00368aca8
+EXTERNAL_SECRETS_OPERATOR_IMAGE=registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:96f1da5cbfdc420342bf60bfca23513f67a12f380a7892da19aaa09043b08e4e


### PR DESCRIPTION
The PR is for the updating the v1.1.1 prod images in the operator bundle.

```
$ podman inspect registry.redhat.io/external-secrets-operator/external-secrets-rhel9@sha256:d3ea7ebb3f3dd8df88ab575e06a670cebe049d38c0783d1104196fe042e2dc45 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/f97bea8e700f7387a2690a601e399951e5b9d80f",
                    "version": "v0.20.4-1"
```

```
$ podman inspect registry.redhat.io/external-secrets-operator/bitwarden-sdk-server-rhel9@sha256:ecdb95c0cb868d273a55675ac39f6ce53cad353da14c74eca040df24bbada721 | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/087b30871871dbfb618f26bd3578172b046d6131",
                    "version": "v0.5.2"
```

```
$ podman inspect registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9@sha256:96f1da5cbfdc420342bf60bfca23513f67a12f380a7892da19aaa09043b08e4e | grep -E "\"version\"|io.openshift.build.commit.url" -m2
                    "io.openshift.build.commit.url": "https://github.com/openshift/external-secrets-operator-release/commit/f97bea8e700f7387a2690a601e399951e5b9d80f",
                    "version": "v1.1.1"
```